### PR TITLE
Pull request for #43: Dependency on package "requests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,19 @@ class CleanRepo(build_py):
         if os.path.isdir('./dist'):
             shutil.rmtree('./dist')
 
+# Requirements
+requirements = []
+requirements.append('requests') # gslab_scons requires the requests module.
 
-setup(name         = 'GSLab_Tools',
-      version      = '2.0.2',
-      description  = 'Python tools for GSLab',
-      url          = 'https://github.com/gslab-econ/gslab_python',
-      author       = 'Matthew Gentzkow, Jesse Shapiro',
-      author_email = 'gentzkow@stanford.edu, jesse_shapiro_1@brown.edu',
-      license      = 'MIT',
-      packages     = find_packages(),
-      zip_safe     = False,
-      cmdclass     = {'clean': CleanRepo})
+setup(name             = 'GSLab_Tools',
+      version          = '2.0.3',
+      description      = 'Python tools for GSLab',
+      url              = 'https://github.com/gslab-econ/gslab_python',
+      author           = 'Matthew Gentzkow, Jesse Shapiro',
+      author_email     = 'gentzkow@stanford.edu, jesse_shapiro_1@brown.edu',
+      license          = 'MIT',
+      packages         = find_packages(),
+      install_requires = requirements, 
+      zip_safe         = False,
+      cmdclass         = {'clean': CleanRepo})
 


### PR DESCRIPTION
@M-R-Sullivan, could you please PR? It's not super high priority, but it should go fairly quickly.

This issue (#43) updates `setup.py` to check for and, if necessary, install the `requests` module when upon installation of the `gslab_python` package. 

PR should ensure that 
  *  The implementation works for `requests` and is done cleanly
  *  No packages are missing from the list of requirements

Let me know if you have any questions. 
