### PR TITLE
Pull request for gslab-econ/template#45: Standardise stata_executable

### DIFF
--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -22,8 +22,8 @@ def build_stata(target, source, env):
         should be the Stata .do script that the builder is intended to execute. 
     env: SCons construction environment, see SCons user guide 7.2
 
-    Note: the user can specify a flavour by typing `scons sf=StataMP` 
-    (By default, SCons will try to find each flavour). 
+    Note: the user can specify a executable by typing `scons sf=StataMP` 
+    (By default, SCons will try to find each executable). 
     '''
 
     # Prelims

--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -21,15 +21,12 @@ def build_stata(target, source, env):
         The source(s) of the SCons command. The first source specified
         should be the Stata .do script that the builder is intended to execute. 
     env: SCons construction environment, see SCons user guide 7.2
-
-    Note: the user can specify a executable by typing `scons sf=StataMP` 
-    (By default, SCons will try to find each executable). 
     '''
 
     # Prelims
-    source       = misc.make_list_if_string(source)
-    target       = misc.make_list_if_string(target)
-    start_time =  misc.current_time()
+    source     = misc.make_list_if_string(source)
+    target     = misc.make_list_if_string(target)
+    start_time = misc.current_time()
 
     # Set up source file and the original location of the log
     source_file = str(source[0])

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -132,10 +132,10 @@ def check_stata(packages = ["yaml"], user_yaml = "user-config.yaml"):
     Check that a valid Stata executable is in the path and that the specified
     Stata packages are installed.
     '''
-    flavor = load_yaml_value(user_yaml, "stata_executable")
+    executable = load_yaml_value(user_yaml, "stata_executable")
 
     # Fake scons-like env dict for misc.get_stata_executable(env)
-    fake_env = {'user_flavor': flavor} 
+    fake_env = {'stata_executable': executable} 
     stata_exec = get_stata_executable(fake_env)
     
     if stata_exec is None:
@@ -144,7 +144,7 @@ def check_stata(packages = ["yaml"], user_yaml = "user-config.yaml"):
     
     command = get_stata_command(stata_exec)
     check_stata_packages(command, packages)
-    return flavor
+    return executable
 
 
 def load_yaml_value(path, key):

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -132,19 +132,18 @@ def check_stata(packages = ["yaml"], user_yaml = "user-config.yaml"):
     Check that a valid Stata executable is in the path and that the specified
     Stata packages are installed.
     '''
-    executable = load_yaml_value(user_yaml, "stata_executable")
-
     # Fake scons-like env dict for misc.get_stata_executable(env)
-    fake_env = {'stata_executable': executable} 
-    stata_exec = get_stata_executable(fake_env)
+    fake_env = {'stata_executable': load_yaml_value(user_yaml, 
+                                                    'stata_executable')} 
+    stata_executable = get_stata_executable(fake_env)
     
-    if stata_exec is None:
+    if stata_executable is None:
         message = 'Stata is not installed or executable is not added to path'
         raise PrerequisiteError(message)
     
-    command = get_stata_command(stata_exec)
+    command = get_stata_command(stata_executable)
     check_stata_packages(command, packages)
-    return executable
+    return stata_executable
 
 
 def load_yaml_value(path, key):

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -85,13 +85,12 @@ def command_line_args(env):
 def get_stata_executable(env):
     '''Return OS command to call Stata.
     
-    This helper function returns a command (str) for Unix Bash or
+    This helper function returns a command (str) for Unix bash or
     Windows cmd to carry a Stata batch job. 
 
-    The function will check for user input in Scons env with
-    the flag e.g. `stata_executable=StataMP-64.exe`. With no user input,
-    the function loops through common Unix and Windows executables
-    and searches them in the system environment.
+    The function checks for a Stata executable in env, an SCons 
+    Environment object. If env does not specify an executable, then 
+    the function searches for common executables in the system environment.
     '''
     # Get environment's user input executable. Empty default = None.
     stata_executable  = env['stata_executable']  
@@ -106,11 +105,9 @@ def get_stata_executable(env):
                     return executable
 
         elif sys.platform == 'win32':
-            try:
-                # Check in system environment variables
-                key_exist = os.environ['STATAEXE'] is not None
+            if 'STATAEXE' in os.environ.keys():
                 return "%%STATAEXE%%"
-            except KeyError:
+            else:
                 # Try StataMP.exe and StataMP-64.exe, etc.
                 executables = [(e.replace('-', '') + '.exe') for e in executables]
                 if is_64_windows():

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -93,17 +93,18 @@ def get_stata_executable(env):
     the function loops through common Unix and Windows executables
     and searches them in the system environment.
     '''
-    # Get environment's user input flavor. Empty default = None.
-    user_flavor  = env['user_flavor']  
+    # Get environment's user input executable. Empty default = None.
+    stata_executable  = env['stata_executable']  
 
-    if user_flavor is not None:
-        return user_flavor
+    if stata_executable is not None:
+        return stata_executable
     else:
-        flavors = ['stata-mp', 'stata-se', 'stata']
+        executables = ['stata-mp', 'stata-se', 'stata']
         if is_unix():
-            for flavor in flavors:
-                if is_in_path(flavor): # check in $PATH
-                    return flavor
+            for executable in executables:
+                if is_in_path(executable): # check in $PATH
+                    return executable
+
         elif sys.platform == 'win32':
             try:
                 # Check in system environment variables
@@ -111,12 +112,12 @@ def get_stata_executable(env):
                 return "%%STATAEXE%%"
             except KeyError:
                 # Try StataMP.exe and StataMP-64.exe, etc.
-                flavors = [(f.replace('-', '') + '.exe') for f in flavors]
+                executables = [(e.replace('-', '') + '.exe') for e in executables]
                 if is_64_windows():
-                    flavors = [f.replace('.exe', '-64.exe') for f in flavors]
-                for flavor in flavors:
-                    if is_in_path(flavor):
-                        return flavor
+                    executables = [e.replace('.exe', '-64.exe') for e in executables]
+                for executable in executables:
+                    if is_in_path(executable):
+                        return executable
     return None
 
 
@@ -128,7 +129,7 @@ def get_stata_command(executable):
     return command
 
 
-def stata_command_unix(flavor):
+def stata_command_unix(executable):
     '''
     This function returns the appropriate Stata command for a user's 
     Unix platform.
@@ -137,17 +138,19 @@ def stata_command_unix(flavor):
                'linux' : '-b',
                'linux2': '-b'}
     option  = options[sys.platform]
-    command = flavor + ' ' + option + ' %s %s'  # %s will take filename and cl_arg later
+
+    # %s will take filename and cl_arg later
+    command = executable + ' ' + option + ' %s %s' 
 
     return command
 
 
-def stata_command_win(flavor):
+def stata_command_win(executable):
     '''
     This function returns the appropriate Stata command for a user's 
     Windows platform.
     '''
-    command  = flavor + ' /e do' + ' %s %s'  # %s will take filename later
+    command  = executable + ' /e do' + ' %s %s'  # %s will take filename later
     return command
 
 

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -89,7 +89,7 @@ def get_stata_executable(env):
     Windows cmd to carry a Stata batch job. 
 
     The function will check for user input in Scons env with
-    the flag e.g. `sf=StataMP-64.exe`. With no user input,
+    the flag e.g. `stata_executable=StataMP-64.exe`. With no user input,
     the function loops through common Unix and Windows executables
     and searches them in the system environment.
     '''

--- a/gslab_scons/tests/test_build_stata.py
+++ b/gslab_scons/tests/test_build_stata.py
@@ -31,9 +31,9 @@ class TestBuildStata(unittest.TestCase):
     def test_unix(self, mock_check, mock_path):
         '''Test build_stata()'s standard behaviour on Unix machines'''
         mock_check.side_effect = fx.make_stata_side_effect('stata-mp')
-        # Mock is_in_path() to finds just one flavor of Stata 
+        # Mock is_in_path() to finds just one executable of Stata 
         mock_path.side_effect  = fx.make_stata_path_effect('stata-mp')
-        env = {'user_flavor' : None}
+        env = {'stata_executable' : None}
         helpers.standard_test(self, gs.build_stata, 'do', 
                               env = env, system_mock = mock_check)
 
@@ -52,7 +52,7 @@ class TestBuildStata(unittest.TestCase):
         mock_path.side_effect  = fx.make_stata_path_effect('statamp.exe')
         mock_is_64.return_value = False
 
-        env = {'user_flavor' : None}
+        env = {'stata_executable' : None}
         helpers.standard_test(self, gs.build_stata, 'do', 
                               env = env, system_mock = mock_check)
 
@@ -85,14 +85,14 @@ class TestBuildStata(unittest.TestCase):
         mock_path.side_effect  = fx.make_stata_path_effect('stata-mp')
 
         # build_stata() will fail to define a command irrespective of
-        # whether a user_flavour is specified
-        env = {'user_flavor' : 'stata-mp'}
+        # whether a stata_executable is specified
+        env = {'stata_executable' : 'stata-mp'}
         with self.assertRaises(NameError):
             gs.build_stata(target = './test_output.txt', 
                            source = './test_script.do', 
                            env    = env)
 
-        env = {'user_flavor' : None}
+        env = {'stata_executable' : None}
         with self.assertRaises(NameError):
             gs.build_stata(target = './test_output.txt', 
                            source = './test_script.do', 
@@ -101,18 +101,18 @@ class TestBuildStata(unittest.TestCase):
 
     @helpers.platform_patch('darwin', path)
     @mock.patch('%s.subprocess.check_output' % path)
-    def test_user_executable_unix(self, mock_check):
+    def test_stata_executable_unix(self, mock_check):
         mock_check.side_effect = fx.make_stata_side_effect('stata-mp')
-        env = {'user_flavor': 'stata-mp'}
+        env = {'stata_executable': 'stata-mp'}
         helpers.standard_test(self, gs.build_stata, 'do', 
                               env = env, system_mock = mock_check)
 
     @helpers.platform_patch('win32', path)
     @mock.patch('%s.subprocess.check_output' % path)
-    def test_user_executable_windows(self, mock_check):
+    def test_stata_executable_windows(self, mock_check):
         mock_check.side_effect = fx.make_stata_side_effect('stata-mp')
 
-        env = {'user_flavor': 'stata-mp'}
+        env = {'stata_executable': 'stata-mp'}
         helpers.standard_test(self, gs.build_stata, 'do', 
                               env = env, system_mock = mock_check)
 
@@ -120,12 +120,12 @@ class TestBuildStata(unittest.TestCase):
     def test_cl_arg(self, mock_check):
         mock_check.side_effect = fx.make_stata_side_effect('stata-mp')
         
-        env = {'user_flavor' : None}
+        env = {'stata_executable' : None}
         helpers.test_cl_args(self, gs.build_stata, mock_check, 'do',
                              env = env)
 
-    def test_bad_user_executable(self):
-        env = {'user_flavor': 'bad_user_executable'}
+    def test_bad_stata_executable(self):
+        env = {'stata_executable': 'bad_stata_executable'}
         with self.assertRaises(BadExecutableError):
             gs.build_stata(target = './test_output.txt', 
                            source = './test_script.do', 
@@ -142,7 +142,7 @@ class TestBuildStata(unittest.TestCase):
         mock_check.side_effect = fx.make_stata_side_effect('')
         mock_path.side_effect  = fx.make_stata_path_effect('')
 
-        env = {'user_flavor': None}
+        env = {'stata_executable': None}
         with helpers.platform_patch('darwin', path), self.assertRaises(TypeError):
             gs.build_stata(target = './test_output.txt', 
                            source = './test_script.do', 
@@ -156,12 +156,12 @@ class TestBuildStata(unittest.TestCase):
     @mock.patch('%s.subprocess.check_output' % path)
     def test_unavailable_executable(self, mock_check):
         '''
-        Test build_stata()'s behaviour when a Stata flavour that 
+        Test build_stata()'s behaviour when a Stata executable that 
         isn't recognised is specified. 
         '''
         mock_check.side_effect = fx.make_stata_side_effect('stata-mp')
 
-        env = {'user_flavor' : 'stata-se'}
+        env = {'stata_executable' : 'stata-se'}
         with self.assertRaises(BadExecutableError):
             gs.build_stata(target = './build/stata.dta', 
                            source = './input/stata_test_script.do', 
@@ -170,7 +170,7 @@ class TestBuildStata(unittest.TestCase):
     @mock.patch('%s.subprocess.check_output' % path)
     def test_bad_extension(self, mock_check):
         mock_check.side_effect = fx.make_stata_side_effect('stata-mp')
-        env = {'user_flavor': 'stata-mp'}
+        env = {'stata_executable': 'stata-mp'}
         helpers.bad_extension(self, gs.build_stata, 
                               good = 'test.do', env = env)
 

--- a/gslab_scons/tests/test_build_stata.py
+++ b/gslab_scons/tests/test_build_stata.py
@@ -135,7 +135,7 @@ class TestBuildStata(unittest.TestCase):
     @mock.patch('%s.subprocess.check_output' % path)
     def test_no_executable_in_path(self, mock_check, mock_path):
         '''
-        Test build_stata()'s behaviour when there no valid Stata
+        Test build_stata()'s behaviour when there are no valid Stata
         executables in the user's path variable
         '''
         # We mock the system to not find any executable in the path.

--- a/gslab_scons/tests/test_configuration_tests.py
+++ b/gslab_scons/tests/test_configuration_tests.py
@@ -247,8 +247,8 @@ class TestConfigurationTests(unittest.TestCase):
                     raise ex_classes.PrerequisiteError()
 
         mock_load_yaml.return_value      = 'statamp'
-        f = lambda x: x['user_flavor'] if x['user_flavor'] is not None \
-                                       else 'statamp'
+        f = lambda x: x['stata_executable'] if x['stata_executable'] is not None \
+                                            else 'statamp'
         mock_stata_exec.side_effect     = f
         mock_stata_command.side_effect  = lambda x: x
         mock_stata_packages.side_effect = stata_package_side_effect

--- a/gslab_scons/tests/test_configuration_tests.py
+++ b/gslab_scons/tests/test_configuration_tests.py
@@ -246,7 +246,7 @@ class TestConfigurationTests(unittest.TestCase):
                 if package != 'yaml':
                     raise ex_classes.PrerequisiteError()
 
-        mock_load_yaml.return_value      = 'statamp'
+        mock_load_yaml.return_value = 'statamp'
         f = lambda x: x['stata_executable'] if x['stata_executable'] is not None \
                                             else 'statamp'
         mock_stata_exec.side_effect     = f
@@ -258,9 +258,8 @@ class TestConfigurationTests(unittest.TestCase):
         self.assertEqual(config_tests.check_stata(), 'statamp')
 
         # No yaml value
-        # Function only returns user-specified executable or none, not the defaults
         mock_load_yaml.return_value = None
-        self.assertEqual(config_tests.check_stata(), None)
+        self.assertEqual(config_tests.check_stata(), 'statamp')
 
         # Failures
         # No yaml value and no default value in path

--- a/test.log
+++ b/test.log
@@ -38,7 +38,7 @@ gslab_scons/tests/test_release_function.py ....
 gslab_scons/tests/test_release_tools.py ....
 gslab_scons/tests/test_size_warning.py .....
 
-========================== 122 passed in 2.14 seconds ==========================
+========================== 122 passed in 2.07 seconds ==========================
 Name                                            Stmts   Miss Branch BrPart  Cover   Missing
 -------------------------------------------------------------------------------------------
 gencat/gencat.py                                   79      6     28      4    91%   72-73, 81, 89, 97, 101, 57->exit, 71->72, 96->97, 100->101
@@ -79,9 +79,9 @@ gslab_scons/builders/build_python.py               24      0      0      0   100
 gslab_scons/builders/build_r.py                    26      0      2      0   100%
 gslab_scons/builders/build_stata.py                30      0      0      0   100%
 gslab_scons/builders/build_tables.py               11      0      0      0   100%
-gslab_scons/configuration_tests.py                134      0     48      0   100%
+gslab_scons/configuration_tests.py                133      0     48      0   100%
 gslab_scons/log.py                                 53      8     16      2    86%   53-54, 79-84, 52->53, 78->79
-gslab_scons/misc.py                               134      0     46      0   100%
+gslab_scons/misc.py                               132      0     48      0   100%
 gslab_scons/release.py                             38     38     18      0     0%   1-65
 gslab_scons/size_warning.py                        69      0     30      0   100%
 gslab_scons/tests/_side_effects.py                112      2     28      7    94%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 246->252
@@ -92,11 +92,11 @@ gslab_scons/tests/test_build_python.py             60      2     14      4    92
 gslab_scons/tests/test_build_r.py                  46      1     12      3    93%   88, 27->exit, 83->exit, 87->88
 gslab_scons/tests/test_build_stata.py              90      1      2      1    98%   179, 178->179
 gslab_scons/tests/test_build_tables.py             65      1      8      1    97%   140, 139->140
-gslab_scons/tests/test_configuration_tests.py     253      3     72      9    96%   212, 244, 402, 108->exit, 207->214, 209->212, 243->244, 284->exit, 291->exit, 316->exit, 344->exit, 401->402
+gslab_scons/tests/test_configuration_tests.py     253      3     72      9    96%   212, 244, 401, 108->exit, 207->214, 209->212, 243->244, 283->exit, 290->exit, 315->exit, 343->exit, 400->401
 gslab_scons/tests/test_log.py                     112     10     12      3    86%   27, 152-158, 194, 198, 26->27, 193->194, 197->198
 gslab_scons/tests/test_misc.py                    136      2     10      2    97%   177, 275, 176->177, 274->275
 gslab_scons/tests/test_release_function.py        122      3     22      2    97%   288-289, 322, 182->exit, 321->322
 gslab_scons/tests/test_release_tools.py            64      1      2      1    97%   153, 152->153
 gslab_scons/tests/test_size_warning.py            183      5     46      6    95%   276, 293, 309, 373, 379, 272->276, 273->276, 292->293, 304->309, 370->373, 378->379
 -------------------------------------------------------------------------------------------
-TOTAL                                            4518   1284   1276     78    66%
+TOTAL                                            4515   1284   1278     78    66%

--- a/test.log
+++ b/test.log
@@ -5,12 +5,10 @@ Processing pytest-3.0.6-py2.7.egg
 
 Using /Users/mrsull/Desktop/gslab_python/.eggs/pytest-3.0.6-py2.7.egg
 running egg_info
-creating GSLab_Tools.egg-info
 writing requirements to GSLab_Tools.egg-info/requires.txt
 writing GSLab_Tools.egg-info/PKG-INFO
 writing top-level names to GSLab_Tools.egg-info/top_level.txt
 writing dependency_links to GSLab_Tools.egg-info/dependency_links.txt
-writing manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 reading manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 writing manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 running build_ext
@@ -40,7 +38,7 @@ gslab_scons/tests/test_release_function.py ....
 gslab_scons/tests/test_release_tools.py ....
 gslab_scons/tests/test_size_warning.py .....
 
-========================== 122 passed in 1.82 seconds ==========================
+========================== 122 passed in 2.14 seconds ==========================
 Name                                            Stmts   Miss Branch BrPart  Cover   Missing
 -------------------------------------------------------------------------------------------
 gencat/gencat.py                                   79      6     28      4    91%   72-73, 81, 89, 97, 101, 57->exit, 71->72, 96->97, 100->101


### PR DESCRIPTION
For gslab-econ/template#45. Specifically, I created this branch in response to [this comment](https://github.com/gslab-econ/template/pull/45#discussion_r117513618).

I should have made `stata_executable` our standard term for referring to users' Stata executables here (rather than `stata_flavor`, `sf`, `user_executable`, etc.). 