### PR TITLE
Pull request for #69: Update tablefill builder with 4.0 logging machinery

### DIFF
--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -1,6 +1,7 @@
 import gslab_scons.misc as misc
 from gslab_fill import tablefill
-
+from gslab_scons import log_timestamp
+from gslab_scons._exception_classes import ExecCallError
 
 def build_tables(target, source, env):
     '''Build a SCons target by filling a table
@@ -23,16 +24,40 @@ def build_tables(target, source, env):
     # Prelims
     source = misc.make_list_if_string(source)
     target = misc.make_list_if_string(target)
+
+    start_time  = misc.current_time()
     
     # Set up source file (table format)
     source_file = str(source[0])
     misc.check_code_extension(source_file, '.lyx')
 
+    # Set up input string (list of data tables)
+    input_string = ' '.join([str(i) for i in source[1:]])
+
     # Set up target file (filled table)
     target_file = str(target[0])
+    target_dir  = misc.get_directory(target_file)    
+    log_file = target_dir + '/sconscript.log'
     misc.check_code_extension(target_file, '.lyx')
     
-    tablefill(input    = ' '.join([str(i) for i in source[1:]]), 
-              template = source_file, 
-              output   = target_file)
+    # Command call
+    command = """tablefill(input = %s, 
+                 template = %s, 
+                 output   = %s)""" % (input_string, source_file, target_file)
+    output  = tablefill(input    = input_string, 
+                        template = source_file, 
+                        output   = target_file)
+
+    if "error" in str.lower(output): # if tablefill.py returns an error            
+        message = misc.command_error_msg("tablefill.py", output + command)
+        with open(log_file, 'wb') as f:
+            f.write(output)
+        raise ExecCallError(message)
+
+    # Close log
+    with open(log_file, 'wb') as f:
+        f.write(output)
+    end_time = misc.current_time()    
+    log_timestamp(start_time, end_time, log_file)
+
     return None

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -37,26 +37,25 @@ def build_tables(target, source, env):
     # Set up target file (filled table)
     target_file = str(target[0])
     target_dir  = misc.get_directory(target_file)    
-    log_file = target_dir + '/sconscript.log'
     misc.check_code_extension(target_file, '.lyx')
+    log_file = target_dir + '/sconscript.log'
     
     # Command call
-    command = """tablefill(input = %s, 
-                 template = %s, 
-                 output   = %s)""" % (input_string, source_file, target_file)
+    command = """tablefill(input    = %s, 
+                         template = %s, 
+                         output   = %s)""" % (input_string, source_file, target_file)
     output  = tablefill(input    = input_string, 
                         template = source_file, 
                         output   = target_file)
-
-    if "error" in str.lower(output): # if tablefill.py returns an error            
-        message = misc.command_error_msg("tablefill.py", command)
-        with open(log_file, 'wb') as f:
-            f.write(output)
-        raise ExecCallError(message)
-
+    
     # Close log
     with open(log_file, 'wb') as f:
         f.write(output)
+
+    if "traceback" in str.lower(output): # if tablefill.py returns an error            
+        message = misc.command_error_msg("tablefill.py", command)
+        raise ExecCallError(message)
+    
     end_time = misc.current_time()    
     log_timestamp(start_time, end_time, log_file)
 

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -49,7 +49,7 @@ def build_tables(target, source, env):
                         output   = target_file)
 
     if "error" in str.lower(output): # if tablefill.py returns an error            
-        message = misc.command_error_msg("tablefill.py", output + command)
+        message = misc.command_error_msg("tablefill.py", command)
         with open(log_file, 'wb') as f:
             f.write(output)
         raise ExecCallError(message)

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -214,9 +214,9 @@ def check_code_extension(source_file, extension):
 def command_error_msg(executable, call):
     ''' This function prints an informative message given a CalledProcessError.'''
     return '''%s did not run successfully.
-              Please check that the executable, source, and target files
-              Check SConstruct.log for errors.
-              Command tried: %s''' % (executable, call) 
+       Please check that the executable, source, and target files
+       Check SConstruct.log for errors.
+Command tried: %s''' % (executable, call) 
 
 
 def current_time():


### PR DESCRIPTION
I found a neater way to do the logging. Turns out `tablefill` has a built-in output return that either prints a happy message when everything works out or a traceback if there's an error. I add code to catch that error and `raise ExecCallError(message)` and have the timestamp matches our conventions. 

Before there was a traceback on Terminal output but no Sconscript log. Sconstruct.log afterwards look like [this](https://gist.github.com/stanfordquan/5ad2b41f96867370fc12fd2f66d6fba6). The Sconscript.log file follows our current logging procedure (timestamps).