### PR TITLE
Pull request for #68: Remove Google Drive from default release

### DIFF
--- a/gslab_scons/README.md
+++ b/gslab_scons/README.md
@@ -19,3 +19,10 @@ from being zipped before their release to Google Drive.
 This release procedure will warn the user when a versioned file
 is larger than 2MB and when the directory's versioned content
 is larger than 500MB in total.  
+
+Instead of entering the GitHub token as a password when using `release`,
+the user can store it `user-config.yaml` in the relevant template as
+
+```
+github_token: <YOUR_TOKEN_HERE>
+```

--- a/gslab_scons/_release_tools.py
+++ b/gslab_scons/_release_tools.py
@@ -50,7 +50,7 @@ def release(vers, org, repo,
 
     json_dump = json.dumps(payload)
     json_dump = re.sub('"FALSE"', 'false', json_dump)
-    posting = session.post(releases_path, data = json_dump)
+    posting   = session.post(releases_path, data = json_dump)
     # Check that the GitHub release was successful
     try:
         posting.raise_for_status()
@@ -84,18 +84,9 @@ def release(vers, org, repo,
         release_id     = json_split[tag_name_index - 1].split(':')[1]
     
         # Get root directory name on drive
-        path     = local_release.split('/')
-        dir_name = None
+        path       = local_release.split('/')
         drive_name = path[-2]
-
-        for i in range(len(path)):
-            if path[i] == 'release' and i + 1 < len(path):
-                dir_name = path[i + 1]
-                break
-
-        if dir_name is None:
-            raise ReleaseError("No /release/ superdirectory found " + 
-                               "in path given by local_release")
+        dir_name   = path[-1]
 
         if not os.path.isdir(local_release):
             os.makedirs(local_release)

--- a/gslab_scons/_release_tools.py
+++ b/gslab_scons/_release_tools.py
@@ -31,7 +31,7 @@ def release(vers, org, repo,
     '''
     # Check the argument types
 
-    if github_token is None:
+    if bool(github_token) is False:
         github_token = getpass.getpass("Enter a GitHub token and then press enter: ") 
     
     tag_name = vers

--- a/gslab_scons/_release_tools.py
+++ b/gslab_scons/_release_tools.py
@@ -15,7 +15,7 @@ def release(vers, org, repo,
             local_release     = '',  
             target_commitish  = '', 
             zip_release       = True,
-            token             = None):
+            github_token      = None):
     '''Publish a release
 
     Parameters
@@ -31,13 +31,13 @@ def release(vers, org, repo,
     '''
     # Check the argument types
 
-    if token is None:
-        token = getpass.getpass("Enter a GitHub token and then press enter: ") 
+    if github_token is None:
+        github_token = getpass.getpass("Enter a GitHub token and then press enter: ") 
     
     tag_name = vers
     
     releases_path = 'https://%s:@api.github.com/repos/%s/%s/releases' \
-                    % (token, org, repo)
+                    % (github_token, org, repo)
     session       = requests.session()
 
     # Create release
@@ -138,22 +138,22 @@ def release(vers, org, repo,
         with open('drive_assets.txt', 'wb') as f:
             f.write('\n'.join([drive_header] + DriveReleaseFiles))
 
-        upload_asset(token      = token, 
-                     org        = org, 
-                     repo       = repo, 
-                     release_id = release_id, 
-                     file_name  = 'drive_assets.txt')
+        upload_asset(github_token = github_token, 
+                     org          = org, 
+                     repo         = repo, 
+                     release_id   = release_id, 
+                     file_name    = 'drive_assets.txt')
 
         os.remove('drive_assets.txt')
 
 
-def upload_asset(token, org, repo, release_id, file_name, 
+def upload_asset(github_token, org, repo, release_id, file_name, 
                  content_type = 'text/markdown'):
     '''
     This function uploads a release asset to GitHub.
 
     --Parameters--
-    token: a GitHub token
+    github_token: a GitHub token
     org: the GitHub organisation to which the repository associated
         with the release belongs
     repo: the GitHub repository associated with the release
@@ -168,7 +168,7 @@ def upload_asset(token, org, repo, release_id, file_name,
         raise ReleaseError('upload_asset() cannot find file_name')
 
     files  = {'file' : open(file_name, 'rU')}
-    header = {'Authorization': 'token %s' % token, 
+    header = {'Authorization': 'token %s' % github_token, 
               'Content-Type':  content_type}
     path_base   = 'https://uploads.github.com/repos'
     upload_path = '%s/%s/%s/releases/%s/assets?name=%s' % \

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -171,7 +171,7 @@ def check_stata_packages(command, packages):
             if re.search('command %s not found' % pkg, log):
                 raise PrerequisiteError('Stata package %s is not installed' % pkg)
 
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError:        
         raise PrerequisiteError("Stata command, '%s', failed.\n" % command.split(' ')[0] + \
                                 "\t\t   Please supply a correct stata_executable" + \
                                 " value in user-config.yaml.\n" )

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -174,4 +174,4 @@ def check_stata_packages(command, packages):
     except subprocess.CalledProcessError:
         raise PrerequisiteError("Stata command, '%s', failed.\n" % command.split(' ')[0] + \
                                 "\t\t   Please supply a correct stata_executable" + \
-                                " value in user_config.yaml.\n" )
+                                " value in user-config.yaml.\n" )

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -4,7 +4,7 @@ import sys
 import importlib
 import subprocess
 import pkg_resources
-from misc import is_in_path, get_stata_executable, get_stata_command, is_unix
+from misc import is_in_path, get_stata_executable, get_stata_command, is_unix, load_yaml_value
 from _exception_classes import PrerequisiteError
 
 
@@ -145,50 +145,6 @@ def check_stata(packages = ["yaml"], user_yaml = "user-config.yaml"):
     check_stata_packages(command, packages)
     return stata_executable
 
-
-def load_yaml_value(path, key):
-    '''
-    Load the yaml value indexed by the key argument in the file
-    specified by the path argument.
-    '''
-    import yaml
-
-    if key == "stata_executable":
-        prompt = "Enter %s value or None to search for defaults: "
-    else:
-        prompt = "Enter %s value: "
-
-    # Check if file exists and is not corrupted. If so, load yaml contents.
-    yaml_contents = None
-    if os.path.isfile(path):
-        try:
-            yaml_contents = yaml.load(open(path, 'rU'))
-            if not isinstance(yaml_contents, dict):
-                raise yaml.scanner.ScannerError()
-
-        except yaml.scanner.ScannerError:
-            message  = "%s is a corrupted yaml file. Delete file and recreate? (y/n) "
-            response = str(raw_input(message % path))
-            if response.lower() == 'y':
-                os.remove(path)
-                yaml_contents = None
-            else:
-                message = "%s is a corrupted yaml file. Please fix." % path
-                raise PrerequisiteError(message)
-
-    # If key exists, return value. Otherwise, add key-value to file.
-    try:
-        if yaml_contents[key] == "None":
-            return None
-        else:
-            return yaml_contents[key]
-    except:
-        with open(path, 'ab') as f:        
-            val = str(raw_input(prompt % key))
-            if re.sub('"', '', re.sub('\'', '', val.lower())) == "none":
-                val = None
-            f.write('%s: %s\n' % (key, val))
-        return val
 
 
 def check_stata_packages(command, packages):

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -4,7 +4,7 @@ import sys
 import importlib
 import subprocess
 import pkg_resources
-from misc import is_in_path, get_stata_executable, get_stata_command, is_unix, load_yaml_value
+from misc import is_in_path, get_stata_executable, get_stata_command, is_unix, load_yaml_value, check_and_expand_path
 from _exception_classes import PrerequisiteError
 
 
@@ -114,19 +114,6 @@ def check_lfs():
                               'git lfs install --force' if prompted above.''')
 
 
-def check_and_expand_cache_path(cache):
-    error_message = " Cache directory, '%s', is not created. " % cache + \
-                    "Please manually create before running.\n\t\t" + \
-                    "    Or fix the path in user-config.yaml.\n"
-    try:
-        cache = os.path.expanduser(cache)
-        if not os.path.isdir(cache):
-            raise PrerequisiteError(error_message)
-        return cache
-    except:
-        raise PrerequisiteError(error_message)
-
-
 def check_stata(packages = ["yaml"], user_yaml = "user-config.yaml"):
     '''
     Check that a valid Stata executable is in the path and that the specified
@@ -175,3 +162,4 @@ def check_stata_packages(command, packages):
         raise PrerequisiteError("Stata command, '%s', failed.\n" % command.split(' ')[0] + \
                                 "\t\t   Please supply a correct stata_executable" + \
                                 " value in user-config.yaml.\n" )
+        

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -245,9 +245,6 @@ def load_yaml_value(path, key):
 
     if key == "stata_executable":
         prompt = "Enter %s value or None to search for defaults: "
-    elif key == "github_token":
-        prompt = "(Optional) Enter %s to be stored in user_config.yaml.\n" + \
-                 "Github token can also be entered without echoing later:" 
     else:
         prompt = "Enter %s value: "
 
@@ -276,11 +273,14 @@ def load_yaml_value(path, key):
         else:
             return yaml_contents[key]
     except:
-        with open(path, 'ab') as f:        
-            val = str(raw_input(prompt % key))
-            if re.sub('"', '', re.sub('\'', '', val.lower())) == "none":
-                val = None
-            f.write('%s: %s\n' % (key, val))
+        if key == "github_token_optional":
+            val = None
+        else:
+            with open(path, 'ab') as f:        
+                val = str(raw_input(prompt % key))
+                if re.sub('"', '', re.sub('\'', '', val.lower())) == "none":
+                    val = None
+                f.write('%s: %s\n' % (key, val))
         return val
 
 

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -245,6 +245,9 @@ def load_yaml_value(path, key):
 
     if key == "stata_executable":
         prompt = "Enter %s value or None to search for defaults: "
+    elif key == "github_token":
+        prompt = "(Optional) Enter %s to be stored in user_config.yaml.\n" + \
+                 "Github token can also be entered without echoing later:" 
     else:
         prompt = "Enter %s value: "
 
@@ -279,6 +282,19 @@ def load_yaml_value(path, key):
                 val = None
             f.write('%s: %s\n' % (key, val))
         return val
+
+
+def check_and_expand_path(path):
+    error_message = " The directory provided, '%s', cannot be found. " % path + \
+                    "Please manually create before running\n" + \
+                    "or fix the path in user-config.yaml.\n"
+    try:
+        path = os.path.expanduser(path)
+        if not os.path.isdir(path):
+            raise _exception_classes.PrerequisiteError(error_message)
+        return path
+    except:
+        raise _exception_classes.PrerequisiteError(error_message)
 
 
 def get_directory(path):

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -5,6 +5,8 @@ import time
 import shutil
 import subprocess
 import datetime
+import yaml
+import getpass
 # Import gslab_scons modules
 import _exception_classes
 from size_warning import issue_size_warnings
@@ -241,13 +243,11 @@ def load_yaml_value(path, key):
     Load the yaml value indexed by the key argument in the file
     specified by the path argument.
     '''
-    import yaml
-
     if key == "stata_executable":
         prompt = "Enter %s or None to search for defaults: "
     elif key == "github_token":
         prompt = "(Optional) Enter %s to be stored in user_config.yaml.\n" 
-        prompt = prompt + "Github token can also be entered without echoing later:" 
+        prompt = prompt + "Github token can also be entered without storing to file later:" 
     else:
         prompt = "Enter %s: "
 
@@ -276,8 +276,11 @@ def load_yaml_value(path, key):
         else:
             return yaml_contents[key]
     except:
-        with open(path, 'ab') as f:        
-            val = str(raw_input(prompt % key))
+        with open(path, 'ab') as f:  
+            if key == "github_token":
+                val = getpass.getpass(prompt = (prompt % key))
+            else:
+                val = str(raw_input(prompt % key))
             if re.sub('"', '', re.sub('\'', '', val.lower())) == "none":
                 val = None
             f.write('%s: %s\n' % (key, val))

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -9,7 +9,7 @@ import datetime
 import _exception_classes
 from size_warning import issue_size_warnings
 
-def scons_debrief(target, source, env):
+def scons_debrief(target, env):
     '''Execute functions after SCons has built all targets'''
     # Log the state of the repo
     env['CL_ARG'] = env['MAXIT']
@@ -22,7 +22,7 @@ def scons_debrief(target, source, env):
     file_MB_limit = float(env['file_MB_limit'])
     total_MB_limit = float(env['total_MB_limit'])
     issue_size_warnings(look_in, file_MB_limit, total_MB_limit)
-
+    return None
 
 def state_of_repo(maxit):
     outfile = 'state_of_repo.log'

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -244,9 +244,12 @@ def load_yaml_value(path, key):
     import yaml
 
     if key == "stata_executable":
-        prompt = "Enter %s value or None to search for defaults: "
+        prompt = "Enter %s or None to search for defaults: "
+    elif key == "github_token":
+        prompt = "(Optional) Enter %s to be stored in user_config.yaml.\n" 
+        prompt = prompt + "Github token can also be entered without echoing later:" 
     else:
-        prompt = "Enter %s value: "
+        prompt = "Enter %s: "
 
     # Check if file exists and is not corrupted. If so, load yaml contents.
     yaml_contents = None
@@ -273,14 +276,11 @@ def load_yaml_value(path, key):
         else:
             return yaml_contents[key]
     except:
-        if key == "github_token_optional":
-            val = None
-        else:
-            with open(path, 'ab') as f:        
-                val = str(raw_input(prompt % key))
-                if re.sub('"', '', re.sub('\'', '', val.lower())) == "none":
-                    val = None
-                f.write('%s: %s\n' % (key, val))
+        with open(path, 'ab') as f:        
+            val = str(raw_input(prompt % key))
+            if re.sub('"', '', re.sub('\'', '', val.lower())) == "none":
+                val = None
+            f.write('%s: %s\n' % (key, val))
         return val
 
 

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -39,8 +39,10 @@ def main(user_yaml = 'user-config.yaml'):
         branch = ''
     else:
         name = "%s-%s" % (repo, branch)
-    local_release = '/%s/%s/' % (release_dir, name)
+    local_release = '%s/%s/' % (release_dir, name)
     local_release = local_release + version + '/'
+    # Get GitHub token:
+    token = load_yaml_value(user_yaml, 'github_token_optional')
     
     _release_tools.release(vers              = version, 
                            DriveReleaseFiles = release_files,
@@ -48,7 +50,8 @@ def main(user_yaml = 'user-config.yaml'):
                            org               = organisation, 
                            repo              = repo,
                            target_commitish  = branch,
-                           zip_release       = zip_release)
+                           zip_release       = zip_release,
+                           token             = token)
 
 
 def inspect_repo():

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -32,7 +32,7 @@ def main(user_yaml = 'user-config.yaml', release_files = []):
                     release_files.append(os.path.join(root, file_name))
 
     # Specify the local release directory
-    release_dir = load_yaml_value(user_yaml, 'release')
+    release_dir = load_yaml_value(user_yaml, 'release_directory')
 
     if branch == 'master':
         name   = repo
@@ -42,7 +42,7 @@ def main(user_yaml = 'user-config.yaml', release_files = []):
     local_release = '%s/%s/' % (release_dir, name)
     local_release = local_release + version + '/'
     # Get GitHub token:
-    github_token = load_yaml_value(user_yaml, 'github_token_optional')
+    github_token = load_yaml_value(user_yaml, 'github_token')
     
     _release_tools.release(vers              = version, 
                            DriveReleaseFiles = release_files,

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -3,14 +3,14 @@ import os
 import sys
 import _release_tools
 from _exception_classes import ReleaseError
+from misc import load_yaml_value
 
-
-def main():
+def main(user_yaml = 'user_config.yaml'):
     inspect_repo()
 
     # Extract information about the clone from its .git directory
     repo, organisation, branch = _release_tools.extract_dot_git()
-    user_config_cache = misc.()
+
     # Determine the version number
     try:
         version = next(arg for arg in sys.argv if re.search("^version=", arg))
@@ -32,12 +32,14 @@ def main():
                 release_files.append(os.path.join(root, file_name))
 
     # Specify the local release directory
+    release_dir = misc.load_yaml_value(user_yaml, 'release')
+
     if branch == 'master':
         name   = repo
         branch = ''
     else:
         name = "%s-%s" % (repo, branch)
-    local_release = '/%s/%s/' % (user_config_cache, name)
+    local_release = '/%s/%s/' % (release_dir, name)
     local_release = local_release + version + '/'
     
     _release_tools.release(vers              = version, 

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -5,7 +5,7 @@ import _release_tools
 from _exception_classes import ReleaseError
 from misc import load_yaml_value
 
-def main(user_yaml = 'user-config.yaml'):
+def main(user_yaml = 'user-config.yaml', release_files = []):
     inspect_repo()
 
     # Extract information about the clone from its .git directory
@@ -23,13 +23,13 @@ def main(user_yaml = 'user-config.yaml'):
     dont_zip    = 'no_zip' in sys.argv
     zip_release = not dont_zip
 
-     # Read a list of files to release to Google Drive
-    release_files = list()
-    for root, _, files in os.walk('./release'):
-        for file_name in files:
-            # Do not release .DS_Store
-            if not re.search("\.DS_Store", file_name):
-                release_files.append(os.path.join(root, file_name))
+    # Read a list of files to release to Google Drive
+    if release_files == []:
+        for root, _, files in os.walk('./release'):
+            for file_name in files:
+                # Do not release .DS_Store
+                if not re.search("\.DS_Store", file_name):
+                    release_files.append(os.path.join(root, file_name))
 
     # Specify the local release directory
     release_dir = load_yaml_value(user_yaml, 'release')
@@ -42,7 +42,7 @@ def main(user_yaml = 'user-config.yaml'):
     local_release = '%s/%s/' % (release_dir, name)
     local_release = local_release + version + '/'
     # Get GitHub token:
-    token = load_yaml_value(user_yaml, 'github_token_optional')
+    github_token = load_yaml_value(user_yaml, 'github_token_optional')
     
     _release_tools.release(vers              = version, 
                            DriveReleaseFiles = release_files,
@@ -51,7 +51,7 @@ def main(user_yaml = 'user-config.yaml'):
                            repo              = repo,
                            target_commitish  = branch,
                            zip_release       = zip_release,
-                           token             = token)
+                           github_token      = github_token)
 
 
 def inspect_repo():

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -5,7 +5,7 @@ import _release_tools
 from _exception_classes import ReleaseError
 from misc import load_yaml_value
 
-def main(user_yaml = 'user_config.yaml'):
+def main(user_yaml = 'user-config.yaml'):
     inspect_repo()
 
     # Extract information about the clone from its .git directory
@@ -32,7 +32,7 @@ def main(user_yaml = 'user_config.yaml'):
                 release_files.append(os.path.join(root, file_name))
 
     # Specify the local release directory
-    release_dir = misc.load_yaml_value(user_yaml, 'release')
+    release_dir = load_yaml_value(user_yaml, 'release')
 
     if branch == 'master':
         name   = repo

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -10,7 +10,7 @@ def main():
 
     # Extract information about the clone from its .git directory
     repo, organisation, branch = _release_tools.extract_dot_git()
-
+    user_config_cache = misc.()
     # Determine the version number
     try:
         version = next(arg for arg in sys.argv if re.search("^version=", arg))
@@ -32,13 +32,12 @@ def main():
                 release_files.append(os.path.join(root, file_name))
 
     # Specify the local release directory
-    USER = os.environ['USER']
     if branch == 'master':
         name   = repo
         branch = ''
     else:
         name = "%s-%s" % (repo, branch)
-    local_release = '/Users/%s/Google Drive/release/%s/' % (USER, name)
+    local_release = '/%s/%s/' % (user_config_cache, name)
     local_release = local_release + version + '/'
     
     _release_tools.release(vers              = version, 

--- a/gslab_scons/release.py
+++ b/gslab_scons/release.py
@@ -3,7 +3,7 @@ import os
 import sys
 import _release_tools
 from _exception_classes import ReleaseError
-from misc import load_yaml_value
+from misc import load_yaml_value, check_and_expand_path
 
 def main(user_yaml = 'user-config.yaml', release_files = []):
     inspect_repo()
@@ -33,6 +33,7 @@ def main(user_yaml = 'user-config.yaml', release_files = []):
 
     # Specify the local release directory
     release_dir = load_yaml_value(user_yaml, 'release_directory')
+    release_dir = check_and_expand_path(release_dir)
 
     if branch == 'master':
         name   = repo
@@ -41,6 +42,8 @@ def main(user_yaml = 'user-config.yaml', release_files = []):
         name = "%s-%s" % (repo, branch)
     local_release = '%s/%s/' % (release_dir, name)
     local_release = local_release + version + '/'
+
+
     # Get GitHub token:
     github_token = load_yaml_value(user_yaml, 'github_token')
     

--- a/gslab_scons/tests/test_build_matlab.py
+++ b/gslab_scons/tests/test_build_matlab.py
@@ -11,7 +11,7 @@ import _side_effects as fx
 sys.path.append('../..')
 import gslab_scons as gs
 from gslab_scons._exception_classes import (BadExtensionError,
-                                            BadExecutableError,
+                                            ExecCallError,
                                             PrerequisiteError)
 
 # Define main test patch
@@ -100,7 +100,7 @@ class TestBuildMatlab(unittest.TestCase):
         mock_check_output.side_effect = \
             fx.make_matlab_side_effect(recognized = False)
 
-        with self.assertRaises(BadExecutableError):
+        with self.assertRaises(ExecCallError):
             gs.build_matlab(target = './build/test.mat', 
                             source = './input/matlab_test_script.m', 
                             env    = {})

--- a/gslab_scons/tests/test_build_r.py
+++ b/gslab_scons/tests/test_build_r.py
@@ -15,7 +15,7 @@ sys.path.append('../..')
 
 import gslab_scons as gs
 from gslab_scons._exception_classes import (BadExtensionError,
-                                            BadExecutableError)
+                                            ExecCallError)
 from gslab_make.tests import nostderrout
 
 system_patch = mock.patch('gslab_scons.builders.build_r.subprocess.check_output')
@@ -57,7 +57,7 @@ class TestBuildR(unittest.TestCase):
         '''
         mock_check_output.side_effect = \
             fx.make_r_side_effect(recognized = False)
-        with self.assertRaises(BadExecutableError):
+        with self.assertRaises(ExecCallError):
             helpers.standard_test(self, gs.build_r, 'R', 
                                   system_mock = mock_check_output)
    

--- a/gslab_scons/tests/test_configuration_tests.py
+++ b/gslab_scons/tests/test_configuration_tests.py
@@ -213,21 +213,6 @@ class TestConfigurationTests(unittest.TestCase):
                 pass
         return side_effect
 
-    @mock.patch('%s.os.path.expanduser' % path)
-    @mock.patch('%s.os.path.isdir' % path)
-    def test_check_and_expand_cache_path(self, mock_is_dir, mock_expanduser):
-        mock_expanduser.side_effect = lambda x: re.sub('~', 'Users/lb', x)
-        mock_is_dir.side_effect     = lambda x: x == 'Users/lb/cache'
-
-        config_tests.check_and_expand_cache_path('~/cache')
-        config_tests.check_and_expand_cache_path('Users/lb/cache')
-        with self.assertRaises(ex_classes.PrerequisiteError):
-            config_tests.check_and_expand_cache_path('~/~/cache')
-        with self.assertRaises(ex_classes.PrerequisiteError):
-            config_tests.check_and_expand_cache_path('lb/cache')
-        with self.assertRaises(ex_classes.PrerequisiteError):
-            config_tests.check_and_expand_cache_path(3)
-
 
     @mock.patch('%s.check_stata_packages' % path)
     @mock.patch('%s.get_stata_executable' % path)

--- a/gslab_scons/tests/test_misc.py
+++ b/gslab_scons/tests/test_misc.py
@@ -341,5 +341,23 @@ class TestMisc(unittest.TestCase):
 
         if os.path.isfile(yaml):
             os.remove(yaml)  
+
+
+    @mock.patch('%s.os.path.expanduser' % path)
+    @mock.patch('%s.os.path.isdir' % path)
+    def test_check_and_expand_path(self, mock_is_dir, mock_expanduser):
+        mock_expanduser.side_effect = lambda x: re.sub('~', 'Users/lb', x)
+        mock_is_dir.side_effect     = lambda x: x == 'Users/lb/cache'
+
+        misc.check_and_expand_path('~/cache')
+        misc.check_and_expand_path('Users/lb/cache')
+        with self.assertRaises(ex_classes.PrerequisiteError):
+            misc.check_and_expand_path('~/~/cache')
+        with self.assertRaises(ex_classes.PrerequisiteError):
+            misc.check_and_expand_path('lb/cache')
+        with self.assertRaises(ex_classes.PrerequisiteError):
+            misc.check_and_expand_path(3)
+
+            
 if __name__ == '__main__':
     unittest.main()

--- a/gslab_scons/tests/test_misc.py
+++ b/gslab_scons/tests/test_misc.py
@@ -31,24 +31,23 @@ class TestMisc(unittest.TestCase):
     @mock.patch('gslab_scons.misc.issue_size_warnings')
     def test_scons_debrief(self, mock_size_warn, mock_repo_state):
         target = 'state_of_repo.log'
-        source = ''
         env    = {'MAXIT': '10', 
                   'look_in': 'release',
                   'file_MB_limit': '1',
                   'total_MB_limit': '2'}
-        misc.scons_debrief(target, source, env)
+        misc.scons_debrief(target, env)
         mock_size_warn.assert_called_with(['release'], 1, 2)
         mock_repo_state.assert_called_with(10)
 
         with self.assertRaises(KeyError):
-            misc.scons_debrief(target, source, {})
+            misc.scons_debrief(target, {})
 
         env = {'MAXIT': 'maxit', 
                'look_in': 'release',
                'file_MB_limit': '1',
                'total_MB_limit': '2'}            
         with self.assertRaises(ValueError):
-            misc.scons_debrief(target, source, env)
+            misc.scons_debrief(target, env)
 
     #== Tests for stata_command_unix() and stata_command_win() ======
     # The tests below patch sys.platform to mock various 

--- a/gslab_scons/tests/test_release_function.py
+++ b/gslab_scons/tests/test_release_function.py
@@ -38,8 +38,9 @@ patch_collection = \
               mock.patch('%s.shutil.copy' % path)(
               mock.patch('%s.shutil.make_archive' % path)(
               mock.patch('%s.shutil.move' % path)(\
+              mock.patch('gslab_scons.misc.check_and_expand_path')(\
                 f \
-              ))))))))))
+              )))))))))))
 
 # Standard release() arguments
 standard_args = {'vers':              'test_version',
@@ -59,6 +60,7 @@ class TestReleaseFunction(unittest.TestCase):
 
     @patch_collection
     def test_release_standard(self, 
+                              mock_cepath,
                               mock_move, 
                               mock_make_archive, 
                               mock_copy, 
@@ -194,6 +196,7 @@ class TestReleaseFunction(unittest.TestCase):
 
     @patch_collection
     def test_release_nozip(self,
+                           mock_cepath,
                            mock_move, 
                            mock_make_archive, 
                            mock_copy, 
@@ -223,6 +226,7 @@ class TestReleaseFunction(unittest.TestCase):
 
     @patch_collection
     def test_release_no_drive(self,
+                              mock_cepath,
                               mock_move, 
                               mock_make_archive, 
                               mock_copy, 
@@ -256,6 +260,7 @@ class TestReleaseFunction(unittest.TestCase):
 
     @patch_collection
     def test_release_unintended_inputs(self,
+                                       mock_cepath,
                                        mock_move, 
                                        mock_make_archive, 
                                        mock_copy, 
@@ -292,9 +297,6 @@ class TestReleaseFunction(unittest.TestCase):
 
         # local_release is of an inappropriate type 
         self.check_failure({'local_release': 1}, AttributeError)
-        # local_release doesn't contain a /release/ subdirectory. Caps matter!
-        self.check_failure({'local_release': 'root/Release/folder'}, 
-                           ReleaseError)
 
         # org/repo referss to a nonexistent GitHub repository
         self.check_failure({'org': 'orgg'}, requests.exceptions.HTTPError)

--- a/gslab_scons/tests/test_release_tools.py
+++ b/gslab_scons/tests/test_release_tools.py
@@ -38,7 +38,7 @@ class TestReleaseTools(unittest.TestCase):
         # iii) the mocked post() method of the mocked session object
         mock_session.return_value = mock.MagicMock(post = mock.MagicMock())
 
-        tools.upload_asset(token        = 'test_token', 
+        tools.upload_asset(github_token = 'test_token', 
                            org          = 'gslab-econ', 
                            repo         = 'gslab_python', 
                            release_id   = 'test_release', 
@@ -71,7 +71,7 @@ class TestReleaseTools(unittest.TestCase):
         mock_session.return_value = mock.MagicMock(post = mock.MagicMock())
 
         with self.assertRaises(ReleaseError), nostderrout():
-            tools.upload_asset(token        = 'test_token', 
+            tools.upload_asset(github_token = 'test_token', 
                                org          = 'gslab-econ', 
                                repo         = 'gslab_python', 
                                release_id   = 'test_release', 

--- a/gslab_scons/tests/user-config.yaml
+++ b/gslab_scons/tests/user-config.yaml
@@ -1,0 +1,1 @@
+stata_executable: 


### PR DESCRIPTION
@lboxell , please review this PR and its companion piece over at `template`. I put three things into this pull requests:

1) I removed Google Drive hard coding in `gslab_python` `release.py`. We now release to a folder that you can specify in `user_config.yaml`.

2) I moved `load_yaml_values` from `configuration_test.py` to `misc.py`. I think that makes a lot more sense since loading from `yaml` is something builders and scripts in `gslab_python` needs to do, not just that `configuration_test.py` script.

3) I moved the `state_of_repo` function to use `atexit` instead of the dependency trick. This is a significant bug that I realized. The `release.py` function that MRS wrote depends on being able to run `scons .` Running `scons .` broke the earlier implementation, since the target is now `.` which means that `.` depends on `state_of_repo.log` depends on `.` (since `state_of_repo.log` is in the top directory `.`). Also `atexit` is what we use to run the logging, so I think we should continue using that. 