### PR TITLE
Pull request for #77: Replace <*> with <source file name> in <sconscript_*.log>

### DIFF
--- a/gslab_scons/builders/build_lyx.py
+++ b/gslab_scons/builders/build_lyx.py
@@ -39,7 +39,11 @@ def build_lyx(target, source, env):
 
     misc.check_code_extension(source_file, 'lyx')
     newpdf   = source_file.replace('.lyx','.pdf')
-    log_file = target_dir + '/sconscript.log'
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except:
+        log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
     
     # System call
     try:

--- a/gslab_scons/builders/build_lyx.py
+++ b/gslab_scons/builders/build_lyx.py
@@ -41,9 +41,9 @@ def build_lyx(target, source, env):
     newpdf   = source_file.replace('.lyx','.pdf')
     try:
         log_ext = '_%s' % env['log_ext']
-    except:
+    except KeyError:
         log_ext = ''
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
+    log_file = os.path.join(target_dir, ('sconscript%s.log' % log_ext))
     
     # System call
     try:

--- a/gslab_scons/builders/build_matlab.py
+++ b/gslab_scons/builders/build_matlab.py
@@ -28,24 +28,29 @@ def build_matlab(target, source, env):
         should be the MATLAB .M script that the builder is intended to execute. 
     env: SCons construction environment, see SCons user guide 7.2
     '''
+    
+    # Prelims
+    source      = misc.make_list_if_string(source)
+    target      = misc.make_list_if_string(target)
+    source_file = str(source[0])
+    target_file = str(target[0])
+    target_dir  = misc.get_directory(target_file)
+    start_time = misc.current_time()
 
+    # MATLAB options
     if misc.is_unix():
         options = '-nosplash -nodesktop'
     elif sys.platform == 'win32':
         options = '-nosplash -minimize -wait'
     else:
         raise PrerequisiteError("Unsupported OS")
-    
-    source      = misc.make_list_if_string(source)
-    target      = misc.make_list_if_string(target)
-    source_file = str(source[0])
-    target_file = str(target[0])
-    target_dir  = misc.get_directory(target_file)
-
-    start_time = misc.current_time()
 
     misc.check_code_extension(source_file, '.m')
-    log_file = target_dir + '/sconscript.log'
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except:
+        log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
 
     # Set up command line arguments
     cl_arg = misc.command_line_args(env)

--- a/gslab_scons/builders/build_matlab.py
+++ b/gslab_scons/builders/build_matlab.py
@@ -28,29 +28,24 @@ def build_matlab(target, source, env):
         should be the MATLAB .M script that the builder is intended to execute. 
     env: SCons construction environment, see SCons user guide 7.2
     '''
-    
-    # Prelims
-    source      = misc.make_list_if_string(source)
-    target      = misc.make_list_if_string(target)
-    source_file = str(source[0])
-    target_file = str(target[0])
-    target_dir  = misc.get_directory(target_file)
-    start_time = misc.current_time()
 
-    # MATLAB options
     if misc.is_unix():
         options = '-nosplash -nodesktop'
     elif sys.platform == 'win32':
         options = '-nosplash -minimize -wait'
     else:
         raise PrerequisiteError("Unsupported OS")
+    
+    source      = misc.make_list_if_string(source)
+    target      = misc.make_list_if_string(target)
+    source_file = str(source[0])
+    target_file = str(target[0])
+    target_dir  = misc.get_directory(target_file)
+
+    start_time = misc.current_time()
 
     misc.check_code_extension(source_file, '.m')
-    try:
-        log_ext = '_%s' % env['log_ext']
-    except:
-        log_ext = ''
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
+    log_file = target_dir + '/sconscript.log'
 
     # Set up command line arguments
     cl_arg = misc.command_line_args(env)
@@ -72,4 +67,4 @@ def build_matlab(target, source, env):
     log_timestamp(start_time, end_time, log_file)
 
     return None
-	
+    

--- a/gslab_scons/builders/build_matlab.py
+++ b/gslab_scons/builders/build_matlab.py
@@ -45,7 +45,11 @@ def build_matlab(target, source, env):
     start_time = misc.current_time()
 
     misc.check_code_extension(source_file, '.m')
-    log_file = target_dir + '/sconscript.log'
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except KeyError:
+        log_ext = ''
+    log_file = os.path.join(target_dir, ('sconscript%s.log' % log_ext))
 
     # Set up command line arguments
     cl_arg = misc.command_line_args(env)

--- a/gslab_scons/builders/build_python.py
+++ b/gslab_scons/builders/build_python.py
@@ -30,7 +30,11 @@ def build_python(target, source, env):
     start_time  = misc.current_time()
 
     misc.check_code_extension(source_file, '.py')
-    log_file = target_dir + '/sconscript.log'
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except:
+        log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
     
     cl_arg = misc.command_line_args(env)
 

--- a/gslab_scons/builders/build_python.py
+++ b/gslab_scons/builders/build_python.py
@@ -32,9 +32,9 @@ def build_python(target, source, env):
     misc.check_code_extension(source_file, '.py')
     try:
         log_ext = '_%s' % env['log_ext']
-    except:
+    except KeyError:
         log_ext = ''
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
+    log_file = os.path.join(target_dir, ('sconscript%s.log' % log_ext))
     
     cl_arg = misc.command_line_args(env)
 

--- a/gslab_scons/builders/build_r.py
+++ b/gslab_scons/builders/build_r.py
@@ -32,9 +32,9 @@ def build_r(target, source, env):
     misc.check_code_extension(source_file, 'r')
     try:
         log_ext = '_%s' % env['log_ext']
-    except:
+    except KeyError:
         log_ext = ''
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
+    log_file = os.path.join(target_dir, ('sconscript%s.log' % log_ext))
     
     cl_arg = misc.command_line_args(env)
 

--- a/gslab_scons/builders/build_r.py
+++ b/gslab_scons/builders/build_r.py
@@ -30,7 +30,11 @@ def build_r(target, source, env):
     start_time  = misc.current_time()
 
     misc.check_code_extension(source_file, 'r')
-    log_file = target_dir + '/sconscript.log'
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except:
+        log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
     
     cl_arg = misc.command_line_args(env)
 

--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -35,8 +35,12 @@ def build_stata(target, source, env):
 
     # Set up log file destination
     target_file = str(target[0])
-    log_dir     = misc.get_directory(target_file)
-    log_file    = log_dir + '/sconscript.log'
+    target_dir  = misc.get_directory(target_file)
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except:
+        log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
     
     # Set up command line arguments
     cl_arg = misc.command_line_args(env)

--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -38,9 +38,9 @@ def build_stata(target, source, env):
     target_dir  = misc.get_directory(target_file)
     try:
         log_ext = '_%s' % env['log_ext']
-    except:
+    except KeyError:
         log_ext = ''
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
+    log_file = os.path.join(target_dir, ('sconscript%s.log' % log_ext))
     
     # Set up command line arguments
     cl_arg = misc.command_line_args(env)

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -38,7 +38,11 @@ def build_tables(target, source, env):
     target_file = str(target[0])
     target_dir  = misc.get_directory(target_file)    
     misc.check_code_extension(target_file, '.lyx')
-    log_file = target_dir + '/sconscript.log'
+    try:
+        log_ext = '_%s' % env['log_ext']
+    except:
+        log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
     
     # Command call
     command = """tablefill(input    = %s, 

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -1,3 +1,4 @@
+import os
 import gslab_scons.misc as misc
 from gslab_fill import tablefill
 from gslab_scons import log_timestamp
@@ -40,9 +41,9 @@ def build_tables(target, source, env):
     misc.check_code_extension(target_file, ['.lyx', '.tex'])
     try:
         log_ext = '_%s' % env['log_ext']
-    except:
+    except KeyError:
         log_ext = ''
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
+    log_file = os.path.join(target_dir, ('sconscript%s.log' % log_ext))
     
     # Command call
     output  = tablefill(input    = input_string, 

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -51,7 +51,7 @@ def build_tables(target, source, env):
     
     with open(log_file, 'wb') as f:
         f.write(output)
-        f.write("\n")
+        f.write("\n\n")
         
     # Close log
     if "traceback" in str.lower(output): # if tablefill.py returns an error   

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -41,8 +41,8 @@ def build_tables(target, source, env):
     try:
         log_ext = '_%s' % env['log_ext']
     except:
-    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
         log_ext = ''
+    log_file    = target_dir + ('/sconscript%s.log' % log_ext)
     
     # Command call
     output  = tablefill(input    = input_string, 

--- a/gslab_scons/log.py
+++ b/gslab_scons/log.py
@@ -77,7 +77,7 @@ def collect_builder_logs(parent_dir):
 
     for root, dirs, files in os.walk(parent_dir): # take a walk in parent and child dirs
         for f in files:
-            if f.endswith("sconscript.log"):
+            if f.startswith('sconscript') and f.endswith('.log'):
                 f_full = os.path.join(root, f)
                 with open(f_full, 'rU') as g:
                     try:

--- a/gslab_scons/tests/test_build_lyx.py
+++ b/gslab_scons/tests/test_build_lyx.py
@@ -67,9 +67,9 @@ class TestBuildLyX(unittest.TestCase):
         target = './build/lyx.pdf'
         source = ['./input/lyx_test_file.lyx']
         log    = './build/sconscript.log'
-
+        
         for env in [True, [1, 2, 3], ('a', 'b'), None, TypeError]:
-            with self.assertRaises(ExecCallError):
+            with self.assertRaises(TypeError):
                 gs.build_lyx(target, source, env = env)
 
     @mock.patch('%s.os.system' % path)
@@ -95,7 +95,7 @@ class TestBuildLyX(unittest.TestCase):
         directory does not exist.
         '''
         mock_system.side_effect = fx.lyx_side_effect
-        with self.assertRaises(ExecCallError):
+        with self.assertRaises(TypeError):
             gs.build_lyx('./nonexistent_directory/lyx.pdf', 
                          ['./input/lyx_test_file.lyx'], env = True)
 

--- a/gslab_scons/tests/test_build_lyx.py
+++ b/gslab_scons/tests/test_build_lyx.py
@@ -69,7 +69,7 @@ class TestBuildLyX(unittest.TestCase):
         log    = './build/sconscript.log'
 
         for env in [True, [1, 2, 3], ('a', 'b'), None, TypeError]:
-            with self.assertRaises(ExecCallError, TypeError):
+            with self.assertRaises(ExecCallError):
                 gs.build_lyx(target, source, env = env)
 
     @mock.patch('%s.os.system' % path)

--- a/gslab_scons/tests/test_build_tables.py
+++ b/gslab_scons/tests/test_build_tables.py
@@ -167,7 +167,7 @@ class TestBuildTables(unittest.TestCase):
         # source is a non-strings non-iterable with no len() value
         source = 1
         with self.assertRaises(TypeError):
-            gs.build_tables(std_target, source, None)\
+            gs.build_tables(std_target, source, None)
 
     def tearDown(self):
         if os.path.exists('./build/'):

--- a/gslab_scons/tests/test_build_tables.py
+++ b/gslab_scons/tests/test_build_tables.py
@@ -42,17 +42,17 @@ class TestBuildTables(unittest.TestCase):
         target = ['./build/tablefill_template_filled.lyx']
         
         # Call build_tables() and check that it behaved as expected.
-        gs.build_tables(target, source, '')
+        gs.build_tables(target, source, {})
         self.check_call(source, target, mock_tablefill)
 
         # The target can also be a tuple
         target = ('./build/tablefill_template_filled.lyx')
-        gs.build_tables(target, source, '')
+        gs.build_tables(target, source, {})
         self.check_call(source, target, mock_tablefill)
 
         # The target can also be a tex file
         target = ('./build/tablefill_template_filled.tex')
-        gs.build_tables(target, source, '')
+        gs.build_tables(target, source, {})
         self.check_call(source, target, mock_tablefill)
 
     def check_call(self, source, target, mock_tablefill):
@@ -93,7 +93,7 @@ class TestBuildTables(unittest.TestCase):
                   './input/tables_appendix.txt', 
                   './input/tables_appendix_two.txt']
         target = './build/tablefill_template_filled.lyx'
-        gs.build_tables(target, source, '')
+        gs.build_tables(target, source, {})
 
         self.check_call(source, target, mock_tablefill)      
 
@@ -108,7 +108,7 @@ class TestBuildTables(unittest.TestCase):
                   './input/tables_appendix_two.txt']
         target = './build/tablefill_template_filled.lyx'
         with self.assertRaises(ExecCallError), nostderrout():
-            gs.build_tables(target, source, '')
+            gs.build_tables(target, source, {})
 
 
     def test_target_extension(self):
@@ -138,10 +138,10 @@ class TestBuildTables(unittest.TestCase):
         mock_tablefill.side_effect = self.table_fill_side_effect
 
         #== env =============
-        # We expect that build_tables() will accept any env argument
         for env in ['', None, Exception, "the environment", (1, 2, 3)]:
-            gs.build_tables(std_target, std_source, env = env)
-            self.check_call(std_source, std_target, mock_tablefill)    
+            with self.assertRaises(TypeError):
+                gs.build_tables(std_target, std_source, env = env)
+                self.check_call(std_source, std_target, mock_tablefill)    
 
         #== target ==========
         # Target argument is not a string or container of strings
@@ -157,17 +157,17 @@ class TestBuildTables(unittest.TestCase):
         # The source isn't a .lyx path
         source = ['nonexistent_file']
         with self.assertRaises(BadExtensionError):
-            gs.build_tables(std_target, source, None)
+            gs.build_tables(std_target, source, {})
 
         # The source is a container of nonstrings.
         source = (True, False, False)
         with self.assertRaises(TypeError):
-            gs.build_tables(std_target, source, None)
+            gs.build_tables(std_target, source, {})
 
         # source is a non-strings non-iterable with no len() value
         source = 1
         with self.assertRaises(TypeError):
-            gs.build_tables(std_target, source, None)
+            gs.build_tables(std_target, source, {})
 
     def tearDown(self):
         if os.path.exists('./build/'):


### PR DESCRIPTION
@arosenbe I added a step in builders for the user to specify a bit in the sconscript_*.log as mentioned in the title. The user specify an argument in `env.BuildSomething` as `log_ext = *`. It should be fairly obvious what happens. There's a PR in `template` as a companion to this.

I would appreciate it if you can help out updating the unittests since you're the Mock expert.

Thanks!