### PR TITLE
Pull request for #92: Change executable-finding behavior in Stata builder

### DIFF
--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -44,10 +44,9 @@ def build_stata(target, source, env):
     
     # Set up command line arguments
     cl_arg = misc.command_line_args(env)
-
-    executable       = misc.get_stata_executable(env)
+    executable = misc.get_stata_executable(env)
     command_skeleton = misc.get_stata_command(executable)
-
+    
     try:
         command = command_skeleton % (source_file, cl_arg)
         subprocess.check_output(command, 
@@ -55,6 +54,8 @@ def build_stata(target, source, env):
                                 shell  = True)
     except subprocess.CalledProcessError:
         message = misc.command_error_msg("Stata", command)
+        if  env['stata_executable'] not in [None, 'None', '']:
+            message = message + 'Maybe try specifying the Stata executable in config_user.yaml?'
         raise ExecCallError(message)
 
     shutil.move(loc_log, log_file)

--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -55,7 +55,7 @@ def build_stata(target, source, env):
     except subprocess.CalledProcessError:
         message = misc.command_error_msg("Stata", command)
         if  env['stata_executable'] not in [None, 'None', '']:
-            message = message + 'Maybe try specifying the Stata executable in config_user.yaml?'
+            message = message + '\n Maybe try specifying the Stata executable in config_user.yaml?'
         raise ExecCallError(message)
 
     shutil.move(loc_log, log_file)

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -124,10 +124,6 @@ def check_stata(packages = ["yaml"], user_yaml = "user-config.yaml"):
                                                     'stata_executable')} 
     stata_executable = get_stata_executable(fake_env)
     
-    if stata_executable is None:
-        message = 'Stata is not installed or executable is not added to path'
-        raise PrerequisiteError(message)
-    
     command = get_stata_command(stata_executable)
     check_stata_packages(command, packages)
     return stata_executable
@@ -159,7 +155,7 @@ def check_stata_packages(command, packages):
                 raise PrerequisiteError('Stata package %s is not installed' % pkg)
 
     except subprocess.CalledProcessError:        
-        raise PrerequisiteError("Stata command, '%s', failed.\n" % command.split(' ')[0] + \
+        raise PrerequisiteError("Stata command, '%s', failed while checking for Stata packages.\n" % command.split(' ')[0] + \
                                 "\t\t   Please supply a correct stata_executable" + \
                                 " value in user-config.yaml.\n" )
         

--- a/gslab_scons/configuration_tests.py
+++ b/gslab_scons/configuration_tests.py
@@ -155,7 +155,5 @@ def check_stata_packages(command, packages):
                 raise PrerequisiteError('Stata package %s is not installed' % pkg)
 
     except subprocess.CalledProcessError:        
-        raise PrerequisiteError("Stata command, '%s', failed while checking for Stata packages.\n" % command.split(' ')[0] + \
-                                "\t\t   Please supply a correct stata_executable" + \
-                                " value in user-config.yaml.\n" )
-        
+        raise PrerequisiteError("Stata command, '%s', failed while checking for Stata packages in configuration test.\n" % command.split(' ')[0] + \
+                                '\n Maybe try specifying the Stata executable in config_user.yaml?'

--- a/gslab_scons/misc.py
+++ b/gslab_scons/misc.py
@@ -87,38 +87,20 @@ def command_line_args(env):
 
 
 def get_stata_executable(env):
-    '''Return OS command to call Stata.
-    
-    This helper function returns a command (str) for Unix bash or
-    Windows cmd to carry a Stata batch job. 
-
-    The function checks for a Stata executable in env, an SCons 
-    Environment object. If env does not specify an executable, then 
-    the function searches for common executables in the system environment.
+    '''
+    This helper function returns the most common Stata executable
+    for Mac/Windows if the default executable is not available in env. 
     '''
     # Get environment's user input executable. Empty default = None.
     stata_executable  = env['stata_executable']  
 
-    if stata_executable is not None:
+    if stata_executable not in [None, 'None', '']:
         return stata_executable
     else:
-        executables = ['stata-mp', 'stata-se', 'stata']
         if is_unix():
-            for executable in executables:
-                if is_in_path(executable): # check in $PATH
-                    return executable
-
+            return 'stata-mp'
         elif sys.platform == 'win32':
-            if 'STATAEXE' in os.environ.keys():
-                return "%%STATAEXE%%"
-            else:
-                # Try StataMP.exe and StataMP-64.exe, etc.
-                executables = [(e.replace('-', '') + '.exe') for e in executables]
-                if is_64_windows():
-                    executables = [e.replace('.exe', '-64.exe') for e in executables]
-                for executable in executables:
-                    if is_in_path(executable):
-                        return executable
+            return 'StataMP-64.exe'
     return None
 
 


### PR DESCRIPTION
- Remove "is executable in path" searching in Stata builder. Now the builder defaults to `stata-mp` on Mac and `StataMP-64.exe` on Windows if `user-config.yaml` does not have a `stata_executable` key, or specify as blank, or specify as "None". 

- The builder sends a message if the builder fails while using one of the default options.

- As the template is set up, the first Stata check is in the `check_stata_packages`  function run in `configuration_test` (since we run stata `which` from the command line). This means that you will never get a builder error for Stata if the configuration test includes running Stata and then fail. This is something to bring up with MG. 