### PR TITLE
Pull Request for #96: Write LaTeX builder

### DIFF
--- a/gslab_scons/__init__.py
+++ b/gslab_scons/__init__.py
@@ -14,6 +14,7 @@ import misc
 import size_warning
 from .log import start_log, log_timestamp
 from .builders.build_r      import build_r
+from .builders.build_latex  import build_latex
 from .builders.build_lyx    import build_lyx
 from .builders.build_stata  import build_stata
 from .builders.build_tables import build_tables

--- a/gslab_scons/builders/build_latex.py
+++ b/gslab_scons/builders/build_latex.py
@@ -7,6 +7,7 @@ from gslab_scons._exception_classes import ExecCallError
 
 def build_latex(target, source, env):
     '''Compile a pdf from a LaTeX file
+
     This function is a SCons builder that compiles a .tex file
     as a pdf and places it at the path specified by target.
 
@@ -43,12 +44,10 @@ def build_latex(target, source, env):
 
     # System call
     try:
-        command = 'pdflatex %s %s > %s' % (source_file, target_dir, log_file)
+        command = 'pdflatex -jobname %s %s > %s' % (target_file.replace('.pdf', ''), source_file, log_file)
         subprocess.check_output(command,
                                 stderr = subprocess.STDOUT,
                                 shell  = True)
-        # Move rendered pdf to the target
-        shutil.move(newpdf, target_file)
     except subprocess.CalledProcessError:
         message = misc.command_error_msg('pdflatex', command)
         raise ExecCallError(message)

--- a/gslab_scons/builders/build_latex.py
+++ b/gslab_scons/builders/build_latex.py
@@ -48,6 +48,7 @@ def build_latex(target, source, env):
         subprocess.check_output(command,
                                 stderr = subprocess.STDOUT,
                                 shell  = True)
+        os.remove(target_file.replace('.pdf', '.log'))
     except subprocess.CalledProcessError:
         message = misc.command_error_msg('pdflatex', command)
         raise ExecCallError(message)

--- a/gslab_scons/builders/build_latex.py
+++ b/gslab_scons/builders/build_latex.py
@@ -44,11 +44,11 @@ def build_latex(target, source, env):
 
     # System call
     try:
-        command = 'pdflatex -jobname %s %s > %s' % (target_file.replace('.pdf', ''), source_file, log_file)
+        command = 'pdflatex -interaction nonstopmode -jobname %s %s > %s' % (target_file.replace('.pdf', ''), source_file, log_file)
         subprocess.check_output(command,
                                 stderr = subprocess.STDOUT,
                                 shell  = True)
-        os.remove(target_file.replace('.pdf', '.log'))
+        # os.remove(target_file.replace('.pdf', '.log'))
     except subprocess.CalledProcessError:
         message = misc.command_error_msg('pdflatex', command)
         raise ExecCallError(message)

--- a/gslab_scons/builders/build_latex.py
+++ b/gslab_scons/builders/build_latex.py
@@ -5,10 +5,9 @@ import gslab_scons.misc as misc
 from gslab_scons import log_timestamp
 from gslab_scons._exception_classes import ExecCallError
 
-def build_lyx(target, source, env):
-    '''Compile a pdf from a LyX file
-
-    This function is a SCons builder that compiles a .lyx file
+def build_latex(target, source, env):
+    '''Compile a pdf from a LaTeX file
+    This function is a SCons builder that compiles a .tex file
     as a pdf and places it at the path specified by target.
 
     Parameters
@@ -18,7 +17,7 @@ def build_lyx(target, source, env):
         of the pdf that the builder is instructed to compile. 
     source: string or list
         The source of the SCons command. This should
-        be the .lyx file that the function will compile as a PDF.
+        be the .tex file that the function will compile as a PDF.
     env: SCons construction environment, see SCons user guide 7.2
     '''
 
@@ -27,7 +26,7 @@ def build_lyx(target, source, env):
     target      = misc.make_list_if_string(target)
 
     source_file = str(source[0])
-    misc.check_code_extension(source_file, '.lyx')
+    misc.check_code_extension(source_file, '.tex')
 
     # Set up target file and log file
     newpdf      = source_file[:-4] + '.pdf'
@@ -44,14 +43,14 @@ def build_lyx(target, source, env):
 
     # System call
     try:
-        command = 'lyx -e pdf2 %s > %s' % (source_file, log_file)
+        command = 'pdflatex %s %s > %s' % (source_file, target_dir, log_file)
         subprocess.check_output(command,
                                 stderr = subprocess.STDOUT,
                                 shell  = True)
         # Move rendered pdf to the target
         shutil.move(newpdf, target_file)
     except subprocess.CalledProcessError:
-        message = misc.command_error_msg('lyx', command)
+        message = misc.command_error_msg('pdflatex', command)
         raise ExecCallError(message)
 
     # Close log

--- a/gslab_scons/tests/_side_effects.py
+++ b/gslab_scons/tests/_side_effects.py
@@ -203,6 +203,8 @@ def latex_side_effect(*args, **kwargs):
     if is_pdflatex and option_type == '-jobname' and source_exists:
         with open('%s.pdf' % target_file, 'wb') as out_file:
             out_file.write('Mock .pdf output')
+        with open('%s.log' % target_file, 'wb') as out_file:
+            out_file.write('Mock .log output')
 
 def make_call_side_effect(text):
     '''

--- a/gslab_scons/tests/_side_effects.py
+++ b/gslab_scons/tests/_side_effects.py
@@ -174,12 +174,15 @@ def latex_side_effect(*args, **kwargs):
     match = helpers.command_match(command, 'pdflatex')
 
     executable   = match.group('executable')
-    option       = match.group('option')
+    option1      = match.group('option1')
+    option2      = match.group('option2')
     source       = match.group('source')
     log_redirect = match.group('log_redirect')
 
-    option_type  = re.findall('^(-\w+)', option)[0]
-    target_file  = re.findall('\s(\S+)', option)[0]
+    option1_type = re.findall('^(-\w+)', option1)[0]
+    interaction  = re.findall('\s(\S+)', option1)[0]
+    option2_type = re.findall('^(-\w+)', option2)[0]
+    target_file  = re.findall('\s(\S+)', option2)[0]
 
     is_pdflatex  = bool(re.search('^pdflatex$', executable, flags = re.I))
 
@@ -200,7 +203,7 @@ def latex_side_effect(*args, **kwargs):
     source_exists  = os.path.abspath(source) in \
                      map(os.path.abspath, existing_files)
 
-    if is_pdflatex and option_type == '-jobname' and source_exists:
+    if is_pdflatex and source_exists and option1_type == '-interaction' and option2_type == '-jobname':
         with open('%s.pdf' % target_file, 'wb') as out_file:
             out_file.write('Mock .pdf output')
         with open('%s.log' % target_file, 'wb') as out_file:

--- a/gslab_scons/tests/_test_helpers.py
+++ b/gslab_scons/tests/_test_helpers.py
@@ -86,11 +86,13 @@ def command_match(command, executable, which = None):
                          command)
 
     elif executable == 'pdflatex':
-        # e.g. "pdflatex -jobname target_file file.tex > ./sconscript.log"
+        # e.g. "pdflatex -interaction nonstopmode -jobname target_file file.tex > ./sconscript.log"
         match = re.match('\s*'
                          '(?P<executable>\w+)'
                          '\s+'
-                         '(?P<option>-\w+ \S+)?'
+                         '(?P<option1>-\w+ \S+)?'
+                         '\s*'
+                         '(?P<option2>-\w+ \S+)?'
                          '\s*'
                          '(?P<source>[\.\/\w]+\.\w+)?'
                          '\s*'

--- a/gslab_scons/tests/_test_helpers.py
+++ b/gslab_scons/tests/_test_helpers.py
@@ -84,7 +84,19 @@ def command_match(command, executable, which = None):
                          '\s*'
                          '(?P<log_redirect>\> [\.\/\w]+\.\w+)?',
                          command)
-     
+
+    elif executable == 'pdflatex':
+        # e.g. "pdflatex -jobname target_file file.tex > ./sconscript.log"
+        match = re.match('\s*'
+                         '(?P<executable>\w+)'
+                         '\s+'
+                         '(?P<option>-\w+ \S+)?'
+                         '\s*'
+                         '(?P<source>[\.\/\w]+\.\w+)?'
+                         '\s*'
+                         '(?P<log_redirect>\> [\.\/\w]+\.\w+)?',
+                         command)
+
     if which:
         return match.group(which)
     else:

--- a/gslab_scons/tests/test_build_latex.py
+++ b/gslab_scons/tests/test_build_latex.py
@@ -1,0 +1,108 @@
+#! /usr/bin/env python
+import unittest
+import sys
+import os
+import shutil
+import mock
+import re
+# Import gslab_scons testing helper modules
+import _test_helpers as helpers
+import _side_effects as fx
+
+# Ensure that Python can find and load the GSLab libraries
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append('../..')
+
+import gslab_scons.builders.build_latex as gs
+from gslab_scons._exception_classes import BadExtensionError, ExecCallError
+
+# Define path to the builder for use in patching
+path = 'gslab_scons.builders.build_latex'
+
+
+class TestBuildLateX(unittest.TestCase):
+
+    def setUp(self):
+        if not os.path.exists('./build/'):
+            os.mkdir('./build/')
+
+    @mock.patch('%s.subprocess.check_output' % path)
+    def test_default(self, mock_system):
+        '''
+        Test that build_latex() behaves correctly when provided with
+        standard inputs. 
+        '''
+        mock_system.side_effect = fx.latex_side_effect
+        target = './build/latex.pdf'
+        helpers.standard_test(self, gs.build_latex, 'tex', 
+                              system_mock = mock_system, 
+                              target = target)
+        self.assertTrue(os.path.isfile(target))
+
+    @mock.patch('%s.subprocess.check_output' % path)
+    def test_list_arguments(self, mock_system):
+        '''
+        Check that build_latex() works when its source and target 
+        arguments are lists
+        '''
+        mock_system.side_effect = fx.latex_side_effect
+        target = ['./build/latex.pdf']
+        helpers.standard_test(self, gs.build_latex, 'tex', 
+                              system_mock = mock_system, 
+                              source = ['./test_script.tex'],
+                              target = target)
+        self.assertTrue(os.path.isfile(target[0]))
+
+    def test_bad_extension(self):
+        '''Test that build_latex() recognises an improper file extension'''
+        helpers.bad_extension(self, gs.build_latex, good = 'test.tex')
+   
+    @mock.patch('%s.os.system' % path)
+    def test_env_argument(self, mock_system):
+        '''
+        Test that numerous types of objects can be passed to 
+        build_latex() without affecting the function's operation.
+        '''
+        mock_system.side_effect = fx.latex_side_effect
+        target = './build/latex.pdf'
+        source = ['./input/latex_test_file.tex']
+        log    = './build/sconscript.log'
+        
+        for env in [True, [1, 2, 3], ('a', 'b'), None, TypeError]:
+            with self.assertRaises(TypeError):
+                gs.build_latex(target, source, env = env)
+
+    @mock.patch('%s.os.system' % path)
+    def test_nonexistent_source(self, mock_system):
+        '''
+        Test build_latex()'s behaviour when the source file
+        does not exist.
+        '''
+        mock_system.side_effect = fx.latex_side_effect
+        # i) Directory doesn't exist
+        with self.assertRaises(ExecCallError):
+            gs.build_latex('./build/latex.pdf', 
+                          ['./bad_dir/latex_test_file.tex'], env = {})
+        # ii) Directory exists, but file doesn't
+        with self.assertRaises(ExecCallError):
+            gs.build_latex('./build/latex.pdf', 
+                          ['./input/nonexistent_file.tex'], env = {})   
+
+    @mock.patch('%s.os.system' % path)
+    def test_nonexistent_target_directory(self, mock_system):
+        '''
+        Test build_latex()'s behaviour when the target file's
+        directory does not exist.
+        '''
+        mock_system.side_effect = fx.latex_side_effect
+        with self.assertRaises(TypeError):
+            gs.build_latex('./nonexistent_directory/latex.pdf', 
+                          ['./input/latex_test_file.tex'], env = True)
+
+    def tearDown(self):
+        if os.path.exists('./build/'):
+            shutil.rmtree('./build/')
+       
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class CleanRepo(build_py):
 requirements = ['requests']
 
 setup(name         = 'GSLab_Tools',
-      version      = '4.0.1',
+      version      = '4.0.2',
       description  = 'Python tools for GSLab',
       url          = 'https://github.com/gslab-econ/gslab_python',
       author       = 'Matthew Gentzkow, Jesse Shapiro',

--- a/test.log
+++ b/test.log
@@ -10,9 +10,9 @@ reading manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 writing manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 running build_ext
 ============================= test session starts ==============================
-platform darwin -- Python 2.7.13, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
-rootdir: /Users/leviboxell/Desktop/gslab_python, inifile: 
-collected 123 items
+platform darwin -- Python 2.7.13, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
+rootdir: /Users/chuanyu/Desktop/gslab_python, inifile:
+collected 129 items
 
 gencat/tests/test_checkDicts.py ...
 gencat/tests/test_cleanDir.py ......
@@ -22,6 +22,7 @@ gencat/tests/test_writeDict.py ....
 gencat/tests/test_zipFile.py ....
 gslab_fill/tests/test_tablefill.py ....
 gslab_fill/tests/test_textfill.py ........
+gslab_scons/tests/test_build_latex.py ......
 gslab_scons/tests/test_build_lyx.py ......
 gslab_scons/tests/test_build_matlab.py ......
 gslab_scons/tests/test_build_python.py ......
@@ -35,7 +36,7 @@ gslab_scons/tests/test_release_function.py ....
 gslab_scons/tests/test_release_tools.py ....
 gslab_scons/tests/test_size_warning.py .....
 
-========================== 123 passed in 1.28 seconds ==========================
+========================== 129 passed in 2.00 seconds ==========================
 Name                                            Stmts   Miss Branch BrPart  Cover   Missing
 -------------------------------------------------------------------------------------------
 gencat/gencat.py                                   79      6     28      4    91%   72-73, 81, 89, 97, 101, 57->exit, 71->72, 96->97, 100->101
@@ -70,7 +71,8 @@ gslab_make/run_program.py                         238    217     80      0     7
 gslab_make/tests/nostderrout.py                    12      0      2      0   100%
 gslab_scons/_exception_classes.py                  11      0      0      0   100%
 gslab_scons/_release_tools.py                     132      0     46      1    99%   34->37
-gslab_scons/builders/build_lyx.py                  32      0      0      0   100%
+gslab_scons/builders/build_latex.py                29      0      0      0   100%
+gslab_scons/builders/build_lyx.py                  30      0      0      0   100%
 gslab_scons/builders/build_matlab.py               38      0      4      0   100%
 gslab_scons/builders/build_python.py               28      0      0      0   100%
 gslab_scons/builders/build_r.py                    32      1      4      1    94%   45, 42->45
@@ -78,11 +80,12 @@ gslab_scons/builders/build_stata.py                34      0      0      0   100
 gslab_scons/builders/build_tables.py               31      0      2      0   100%
 gslab_scons/configuration_tests.py                 94      0     34      0   100%
 gslab_scons/log.py                                 74     21     16      3    71%   53-59, 87, 92-93, 97-108, 52->53, 84->87, 96->97
-gslab_scons/misc.py                               184      3     72      3    98%   260-261, 292, 61->49, 259->260, 291->292
+gslab_scons/misc.py                               184      3     72      2    98%   260-261, 292, 259->260, 291->292
 gslab_scons/release.py                             41     41     20      0     0%   1-72
 gslab_scons/size_warning.py                        70      0     30      0   100%
-gslab_scons/tests/_side_effects.py                112      2     28      7    94%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 246->252
-gslab_scons/tests/_test_helpers.py                 95      4     34      3    93%   27-28, 102, 117, 76->88, 99->102, 112->117
+gslab_scons/tests/_side_effects.py                131      2     32      9    93%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 187->199, 203->exit, 286->292
+gslab_scons/tests/_test_helpers.py                 97      4     36      3    93%   27-28, 114, 129, 88->100, 111->114, 124->129
+gslab_scons/tests/test_build_latex.py              52      1      8      3    93%   108, 26->exit, 103->exit, 107->108
 gslab_scons/tests/test_build_lyx.py                52      1      8      3    93%   108, 26->exit, 103->exit, 107->108
 gslab_scons/tests/test_build_matlab.py             54      1      6      1    97%   110, 109->110
 gslab_scons/tests/test_build_python.py             60      2     14      4    92%   75, 107, 23->exit, 74->75, 102->exit, 106->107
@@ -96,4 +99,4 @@ gslab_scons/tests/test_release_function.py        121      3     22      2    97
 gslab_scons/tests/test_release_tools.py            64      1      2      1    97%   153, 152->153
 gslab_scons/tests/test_size_warning.py            183      5     46      6    95%   277, 294, 310, 374, 380, 273->277, 274->277, 293->294, 305->310, 371->374, 379->380
 -------------------------------------------------------------------------------------------
-TOTAL                                            4603   1305   1292     86    66%
+TOTAL                                            4703   1306   1306     90    67%

--- a/test.log
+++ b/test.log
@@ -34,7 +34,7 @@ gslab_scons/tests/test_release_function.py ....
 gslab_scons/tests/test_release_tools.py ....
 gslab_scons/tests/test_size_warning.py .....
 
-========================== 129 passed in 2.26 seconds ==========================
+========================== 129 passed in 1.18 seconds ==========================
 Name                                            Stmts   Miss Branch BrPart  Cover   Missing
 -------------------------------------------------------------------------------------------
 gencat/gencat.py                                   79      6     28      4    91%   72-73, 81, 89, 97, 101, 57->exit, 71->72, 96->97, 100->101
@@ -69,7 +69,7 @@ gslab_make/run_program.py                         238    217     80      0     7
 gslab_make/tests/nostderrout.py                    12      0      2      0   100%
 gslab_scons/_exception_classes.py                  11      0      0      0   100%
 gslab_scons/_release_tools.py                     132      0     46      1    99%   34->37
-gslab_scons/builders/build_latex.py                30      0      0      0   100%
+gslab_scons/builders/build_latex.py                29      0      0      0   100%
 gslab_scons/builders/build_lyx.py                  30      0      0      0   100%
 gslab_scons/builders/build_matlab.py               38      0      4      0   100%
 gslab_scons/builders/build_python.py               28      0      0      0   100%
@@ -81,8 +81,8 @@ gslab_scons/log.py                                 74     21     16      3    71
 gslab_scons/misc.py                               184      3     72      2    98%   260-261, 292, 259->260, 291->292
 gslab_scons/release.py                             41     41     20      0     0%   1-72
 gslab_scons/size_warning.py                        70      0     30      0   100%
-gslab_scons/tests/_side_effects.py                133      2     32      9    93%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 187->199, 203->exit, 288->294
-gslab_scons/tests/_test_helpers.py                 97      4     36      3    93%   27-28, 114, 129, 88->100, 111->114, 124->129
+gslab_scons/tests/_side_effects.py                136      2     32      9    93%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 190->202, 206->exit, 291->297
+gslab_scons/tests/_test_helpers.py                 97      4     36      3    93%   27-28, 116, 131, 88->102, 113->116, 126->131
 gslab_scons/tests/test_build_latex.py              52      1      8      3    93%   108, 26->exit, 103->exit, 107->108
 gslab_scons/tests/test_build_lyx.py                52      1      8      3    93%   108, 26->exit, 103->exit, 107->108
 gslab_scons/tests/test_build_matlab.py             54      1      6      1    97%   110, 109->110
@@ -97,4 +97,4 @@ gslab_scons/tests/test_release_function.py        121      3     22      2    97
 gslab_scons/tests/test_release_tools.py            64      1      2      1    97%   153, 152->153
 gslab_scons/tests/test_size_warning.py            183      5     46      6    95%   277, 294, 310, 374, 380, 273->277, 274->277, 293->294, 305->310, 371->374, 379->380
 -------------------------------------------------------------------------------------------
-TOTAL                                            4706   1306   1306     90    67%
+TOTAL                                            4708   1306   1306     90    67%

--- a/test.log
+++ b/test.log
@@ -1,11 +1,9 @@
 running pytest
 running egg_info
-creating GSLab_Tools.egg-info
 writing requirements to GSLab_Tools.egg-info/requires.txt
 writing GSLab_Tools.egg-info/PKG-INFO
 writing top-level names to GSLab_Tools.egg-info/top_level.txt
 writing dependency_links to GSLab_Tools.egg-info/dependency_links.txt
-writing manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 reading manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 writing manifest file 'GSLab_Tools.egg-info/SOURCES.txt'
 running build_ext
@@ -36,7 +34,7 @@ gslab_scons/tests/test_release_function.py ....
 gslab_scons/tests/test_release_tools.py ....
 gslab_scons/tests/test_size_warning.py .....
 
-========================== 129 passed in 2.00 seconds ==========================
+========================== 129 passed in 2.26 seconds ==========================
 Name                                            Stmts   Miss Branch BrPart  Cover   Missing
 -------------------------------------------------------------------------------------------
 gencat/gencat.py                                   79      6     28      4    91%   72-73, 81, 89, 97, 101, 57->exit, 71->72, 96->97, 100->101
@@ -71,7 +69,7 @@ gslab_make/run_program.py                         238    217     80      0     7
 gslab_make/tests/nostderrout.py                    12      0      2      0   100%
 gslab_scons/_exception_classes.py                  11      0      0      0   100%
 gslab_scons/_release_tools.py                     132      0     46      1    99%   34->37
-gslab_scons/builders/build_latex.py                29      0      0      0   100%
+gslab_scons/builders/build_latex.py                30      0      0      0   100%
 gslab_scons/builders/build_lyx.py                  30      0      0      0   100%
 gslab_scons/builders/build_matlab.py               38      0      4      0   100%
 gslab_scons/builders/build_python.py               28      0      0      0   100%
@@ -83,7 +81,7 @@ gslab_scons/log.py                                 74     21     16      3    71
 gslab_scons/misc.py                               184      3     72      2    98%   260-261, 292, 259->260, 291->292
 gslab_scons/release.py                             41     41     20      0     0%   1-72
 gslab_scons/size_warning.py                        70      0     30      0   100%
-gslab_scons/tests/_side_effects.py                131      2     32      9    93%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 187->199, 203->exit, 286->292
+gslab_scons/tests/_side_effects.py                133      2     32      9    93%   34-35, 31->34, 37->exit, 49->exit, 73->78, 144->156, 160->exit, 187->199, 203->exit, 288->294
 gslab_scons/tests/_test_helpers.py                 97      4     36      3    93%   27-28, 114, 129, 88->100, 111->114, 124->129
 gslab_scons/tests/test_build_latex.py              52      1      8      3    93%   108, 26->exit, 103->exit, 107->108
 gslab_scons/tests/test_build_lyx.py                52      1      8      3    93%   108, 26->exit, 103->exit, 107->108
@@ -99,4 +97,4 @@ gslab_scons/tests/test_release_function.py        121      3     22      2    97
 gslab_scons/tests/test_release_tools.py            64      1      2      1    97%   153, 152->153
 gslab_scons/tests/test_size_warning.py            183      5     46      6    95%   277, 294, 310, 374, 380, 273->277, 274->277, 293->294, 305->310, 371->374, 379->380
 -------------------------------------------------------------------------------------------
-TOTAL                                            4703   1306   1306     90    67%
+TOTAL                                            4706   1306   1306     90    67%


### PR DESCRIPTION
@stanfordquan @Shun-Yang , can any of you PR when you get time? The executable I use for the builder is `pdflatex`. The builder and the tests are very similar to those of `build_lyx`. I also test it in template, and it seems to work fine.

One thing is that the current builder does not delete auxiliary files like `aux`, etc. The pdf would be compiled much faster after the first run if these auxiliary files exist. We always add these auxiliary files in [.gitignore](https://github.com/gslab-econ/template/blob/eaebce91590df81dcd788c9d8eac000f68d8007e/.gitignore), so they won't get committed.