### PR TITLE
Pull request for #93: add moving top level log to end_log 

### DIFF
--- a/gslab_scons/log.py
+++ b/gslab_scons/log.py
@@ -108,3 +108,8 @@ def collect_builder_logs(parent_dir):
         builder_log_collect[log_path]  = builder_log_end_time
 
     return builder_log_collect
+
+def move_log(cur_location = '.', target_location = 'release'):
+    for file in glob.glob("*.log"):
+        shutil.move('%s/' + file % cur_location, '%s/' + file % target_location)
+    return None

--- a/gslab_scons/log.py
+++ b/gslab_scons/log.py
@@ -3,6 +3,7 @@ import sys
 import glob
 from datetime import datetime
 import subprocess
+import shutil
 import gslab_scons.misc as misc
 
 
@@ -58,8 +59,10 @@ def end_log(log = 'sconstruct.log'):
                 sconstruct.write(f + '\n')
                 sconstruct.write(sconscript.read())
 
+    # move top level logs to /release/ directory.
+    for file in glob.glob("*.log"):
+        shutil.move('./' + file, 'release/' + file)
     return None
-
 
 def log_timestamp(start_time, end_time, filename = 'sconstruct.log'):
     '''Adds beginning and ending times to a log file.'''
@@ -108,8 +111,3 @@ def collect_builder_logs(parent_dir):
         builder_log_collect[log_path]  = builder_log_end_time
 
     return builder_log_collect
-
-def move_log(cur_location = '.', target_location = 'release'):
-    for file in glob.glob("*.log"):
-        shutil.move('%s/' + file % cur_location, '%s/' + file % target_location)
-    return None

--- a/gslab_scons/log.py
+++ b/gslab_scons/log.py
@@ -111,3 +111,4 @@ def collect_builder_logs(parent_dir):
         builder_log_collect[log_path]  = builder_log_end_time
 
     return builder_log_collect
+    

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class CleanRepo(build_py):
 requirements = ['requests']
 
 setup(name         = 'GSLab_Tools',
-      version      = '4.0.1',
+      version      = '4.1.0',
       description  = 'Python tools for GSLab',
       url          = 'https://github.com/gslab-econ/gslab_python',
       author       = 'Matthew Gentzkow, Jesse Shapiro',


### PR DESCRIPTION
@stanfordquan, see #93. The parallel pull is gslab-econ/template#75. Should be quick.