### PR TITLE
Pull request for #94: allow folders to be excluded from search

### DIFF
--- a/gslab_scons/log.py
+++ b/gslab_scons/log.py
@@ -90,7 +90,7 @@ def collect_builder_logs(parent_dir, excluded_dirs = []):
     log_name = 'sconscript*.log'
     excluded_dirs = misc.make_list_if_string(excluded_dirs)
     if misc.is_unix():
-        command = 'find %s -name "%s -type f"' % (rel_parent_dir, log_name)
+        command = 'find %s -name "%s" -type f' % (rel_parent_dir, log_name)
         for x in excluded_dirs: # add in args to exclude folders from search
             command = '%s -not -path "*%s*"' % (command, os.path.normpath(x)) 
     else:

--- a/gslab_scons/log.py
+++ b/gslab_scons/log.py
@@ -27,7 +27,7 @@ def start_log(mode, vers, log = 'sconstruct.log'):
     return None
 
 
-def end_log(log = 'sconstruct.log'):
+def end_log(log = 'sconstruct.log', excluded_dirs = []):
     '''Complete the log of a build process.'''
 
     end_message = "*** Build completed: {%s} ***\n \n \n" % misc.current_time()
@@ -42,7 +42,7 @@ def end_log(log = 'sconstruct.log'):
 
     # gather all sconscript logs 
     parent_dir = os.getcwd()
-    builder_logs = collect_builder_logs(parent_dir)
+    builder_logs = collect_builder_logs(parent_dir, excluded_dirs = excluded_dirs)
     
     # keep only builder logs from this run OR is broken (value == beginning_of_time)
     beginning_of_time    = datetime.min # to catch broken logs (see collect_builder_logs)


### PR DESCRIPTION
@yuchuan2016 this should be fairly simple.

I added an argument in `collect_builder_logs` called `excluded_dirs` (which is passed by the user when calling `log.end_log` at `atexit` in `template`. This argument is a str or list of str of directories to be excluded when we search for sconscript.log files to collect in the `sconstruct.log`.

Let me know if there's any question! Thanks