### PR TITLE
Pull request for #122: Delete old local gslab_python versions upon both installation methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if True in is_include_arg:
 else:
     include_arg = None
 
-with open('Users/arosenbe/Desktop/A', 'wb') as f:
+with open('/Users/arosenbe/Desktop/A', 'wb') as f:
     f.write('AAAA')
 
 class TestRepo(build_py):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if True in is_include_arg:
 else:
     include_arg = None
 
-with open('~/Desktop/A', 'wb') as f:
+with open('Users/arosenbe/Desktop/A', 'wb') as f:
     f.write('AAAA')
 
 class TestRepo(build_py):

--- a/setup.py
+++ b/setup.py
@@ -57,15 +57,6 @@ class CleanRepo(build_py):
         if os.path.isdir('./dist'):
             shutil.rmtree('./dist')
 
-class ClearOld(build_py):
-    '''
-    Build commands for deleteing old versions of 
-    ''' 
-    def run(self):
-
-        locations = site.getsitepackages()
-
-
 # Requirements
 requirements = ['requests', 'scandir', 'mmh3']
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import shutil
-import pip
+import site
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
 from setuptools.command.install import install

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import shutil
-import site
+import pip
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
 from setuptools.command.install import install
@@ -19,9 +19,16 @@ if True in is_include_arg:
 else:
     include_arg = None
 
-with open('/Users/arosenbe/Desktop/A', 'wb') as f:
-    f.write('AAAA')
+# Uninstall old versions of GSLab-Tools
+re_gslab  = re.compile('gslab[-_].', re.IGNORECASE)
+re_gencat = re.compile('gencat')
+package_location = site.getsitepackages()[0]
+packages = os.listdir(package_location)
+for package in packages:
+    if re_gslab.match(package) or re_gencat.match(package):
+        shutil.rmtree(os.path.join(package_location, package))
 
+# Additional build commands
 class TestRepo(build_py):
     '''Build command for running tests in repo'''
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@ import os
 import re
 import sys
 import shutil
+import site
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
+from setuptools.command.install import install
 from glob import glob
  
 # Determine if the user has specified which paths to report coverage for
@@ -17,6 +19,8 @@ if True in is_include_arg:
 else:
     include_arg = None
 
+with open('~/Desktop/A', 'wb') as f:
+    f.write('AAAA')
 
 class TestRepo(build_py):
     '''Build command for running tests in repo'''
@@ -52,6 +56,15 @@ class CleanRepo(build_py):
             shutil.rmtree('./build')
         if os.path.isdir('./dist'):
             shutil.rmtree('./dist')
+
+class ClearOld(build_py):
+    '''
+    Build commands for deleteing old versions of 
+    ''' 
+    def run(self):
+
+        locations = site.getsitepackages()
+
 
 # Requirements
 requirements = ['requests', 'scandir', 'mmh3']


### PR DESCRIPTION
@stanfordquan, can you please PR my work from #122. The idea is to look through the current default python package installation location and destroy every gslab package there. We don't ask, and we don't tell. This's basically the same behavior as pip, just a little quieter. 

I opted for shutil.rmtree over `pip uninstall` because it's sure to catch all versions of GSLab, even if multiple versions exist of they were installed through unorthodox means. 

One thing to note is that this implementation only checks the default package installation location. If the user specifies another location, may God have mercy on her soul...