### PR TITLE
Pull request for #147: Logging breaks if a folder has space in its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GSLab Python Library Collection 4.1.0
+# GSLab Python Library Collection 4.1.1
 
 Overview
 --------

--- a/gslab_scons/builders/gslab_builder.py
+++ b/gslab_scons/builders/gslab_builder.py
@@ -1,6 +1,7 @@
 import abc
 import os
 import subprocess
+import re
 import sys
 
 import gslab_scons.misc as misc
@@ -105,7 +106,7 @@ class GSLabBuilder(object):
         start_time = misc.current_time()
         self.do_call()
         self.check_targets()
-        end_time =  misc.current_time()    
+        end_time = misc.current_time()
         self.timestamp_log(start_time, end_time)
         return None
 
@@ -170,12 +171,14 @@ class GSLabBuilder(object):
         '''
         Adds beginning and ending times to a log file made for system call.
         '''
-        with open(self.log_file, mode = 'rU') as f:
+        # Remove quotes wrapping log file
+        log_file = re.match("^'(.*?)'$", self.log_file).groups()[0]
+        with open(log_file, mode = 'rU') as f:
             content = f.read()
             f.seek(0, 0)
             builder_log_msg = '*** Builder log created: {%s}\n' \
                               '*** Builder log completed: {%s}\n%s' \
                               % (start_time, end_time, content)
-        with open(self.log_file, mode = 'wb') as f:
+        with open(log_file, mode = 'wb') as f:
             f.write(builder_log_msg)
         return None

--- a/gslab_scons/builders/gslab_builder.py
+++ b/gslab_scons/builders/gslab_builder.py
@@ -82,7 +82,8 @@ class GSLabBuilder(object):
             log_ext = '_%s' % self.env['log_ext']
         except KeyError:
             log_ext = ''
-        self.log_file = os.path.join(self.target_dir, ('sconscript%s.log' % log_ext))
+        log_file = os.path.join(self.target_dir, ('sconscript%s.log' % log_ext))
+        self.log_file = "'%s'" % log_file
         return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ class CleanRepo(build_py):
 requirements = ['requests', 'scandir', 'mmh3']
 
 setup(name         = 'GSLab_Tools',
-      version      = '4.1.0',
+      version      = '4.1.1',
       description  = 'Python tools for GSLab',
       url          = 'https://github.com/gslab-econ/gslab_python',
       author       = 'Matthew Gentzkow, Jesse Shapiro',


### PR DESCRIPTION
Thanks @stanfordquan! Can you review my work from #147. The issue was that spaces in the log file weren't correctly formatted for execution on the shell. I fixed this by wrapping the log file in quotes. 

This also required a small change in how we find the log file for time-stamping. 

