### PR TITLE
Pull request for #157: Missing import in matlab builder?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GSLab Python Library Collection 4.1.1
+# GSLab Python Library Collection 4.1.2
 
 Overview
 --------

--- a/gslab_scons/builders/build_anything.py
+++ b/gslab_scons/builders/build_anything.py
@@ -76,7 +76,6 @@ class AnythingBuilder(GSLabBuilder):
                               'The Anything Builder\'s logging mechanism '\
                               'may not work as intended.'
             warnings.warn(warning_message)
-        return None
 
 
     @staticmethod

--- a/gslab_scons/builders/build_matlab.py
+++ b/gslab_scons/builders/build_matlab.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import hashlib
+import sys
 
 import gslab_scons.misc as misc
 from gslab_builder import GSLabBuilder

--- a/gslab_scons/builders/build_matlab.py
+++ b/gslab_scons/builders/build_matlab.py
@@ -37,7 +37,6 @@ class MatlabBuilder(GSLabBuilder):
         super(MatlabBuilder, self).__init__(target, source, env, name = name,
                                             exec_opts = exec_opts,
                                             valid_extensions = valid_extensions)
-        return None
 
 
     def add_executable_options(self):

--- a/gslab_scons/builders/build_matlab.py
+++ b/gslab_scons/builders/build_matlab.py
@@ -33,9 +33,9 @@ class MatlabBuilder(GSLabBuilder):
     def __init__(self, target, source, env, name = '', valid_extensions = []):
         '''
         '''
-        self.add_executable_options()
+        exec_opts = self.add_executable_options()
         super(MatlabBuilder, self).__init__(target, source, env, name = name,
-                                            exec_opts = self.exec_opts,
+                                            exec_opts = exec_opts,
                                             valid_extensions = valid_extensions)
         return None
 
@@ -51,8 +51,7 @@ class MatlabBuilder(GSLabBuilder):
             message = 'Cannot find MATLAB command line syntax for platform.'
             raise PrerequisiteError(message)
         options = ' -nosplash %s -r' % platform_option
-        self.exec_opts = options
-        return None
+        return options
 
 
     def add_call_args(self):

--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -39,7 +39,6 @@ class StataBuilder(GSLabBuilder):
         super(StataBuilder, self).__init__(target, source, env, name = name,
                                            exec_opts = exec_opts,
                                            valid_extensions = valid_extensions)
-        return None
 
 
     def add_log_file(self):

--- a/gslab_scons/builders/build_stata.py
+++ b/gslab_scons/builders/build_stata.py
@@ -35,9 +35,9 @@ class StataBuilder(GSLabBuilder):
     def __init__(self, target, source, env, name = '', valid_extensions = []):
         '''
         '''
-        self.add_executable_options()
+        exec_opts = self.add_executable_options()
         super(StataBuilder, self).__init__(target, source, env, name = name,
-                                           exec_opts = self.exec_opts,
+                                           exec_opts = exec_opts,
                                            valid_extensions = valid_extensions)
         return None
 
@@ -63,8 +63,7 @@ class StataBuilder(GSLabBuilder):
         except KeyError:
             message = 'Cannot find Stata command line syntax for platform %s.' % sys.platform
             raise PrerequisiteError(message)
-        self.exec_opts = options
-        return None
+        return options
 
 
     def add_call_args(self):

--- a/gslab_scons/builders/build_tables.py
+++ b/gslab_scons/builders/build_tables.py
@@ -42,7 +42,6 @@ class TableBuilder(GSLabBuilder):
                                           exec_opts = exec_opts)
         self.input_string = ' '.join([str(i) for i in source[1:]])
         self.target_file  = os.path.normpath(self.target[0])
-        return None
 
 
     def add_call_args(self):

--- a/gslab_scons/builders/gslab_builder.py
+++ b/gslab_scons/builders/gslab_builder.py
@@ -51,7 +51,6 @@ class GSLabBuilder(object):
         self.add_log_file()
         self.add_call_args()
         self.system_call = '%s %s %s' % (self.executable, self.exec_opts, self.call_args)
-        return None
 
 
     def add_source_file(self, source):

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class CleanRepo(build_py):
 requirements = ['requests', 'scandir', 'mmh3']
 
 setup(name         = 'GSLab_Tools',
-      version      = '4.1.1',
+      version      = '4.1.2',
       description  = 'Python tools for GSLab',
       url          = 'https://github.com/gslab-econ/gslab_python',
       author       = 'Matthew Gentzkow, Jesse Shapiro',


### PR DESCRIPTION
@z-y-huang, can you PR my work for #157? (I know how much you like working with python builders.)

The bug was the missing `import sys` in build_matlab.py. I also took the opportunity to clear up some icky argument passing for matlab and stata. 
  